### PR TITLE
feat(scripts): Add router-peer defense-in-depth hardening

### DIFF
--- a/scripts/router-peer/99-netbird-hardening.conf
+++ b/scripts/router-peer/99-netbird-hardening.conf
@@ -1,0 +1,61 @@
+# NetBird Router-Peer Defense-in-Depth Configuration
+# This file configures kernel-level network security for the router-peer.
+# Install to: /etc/sysctl.d/99-netbird-hardening.conf
+# Apply with: sudo sysctl -p /etc/sysctl.d/99-netbird-hardening.conf
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ANTI-SPOOFING (Reverse Path Filtering)
+# ═══════════════════════════════════════════════════════════════════════════
+# Strict mode (1): Drop packets if reply would go out different interface
+# This prevents IP spoofing attacks where attacker forges source IP
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+
+# Log martian packets (packets with impossible source addresses)
+# Useful for detecting spoofing attempts
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ICMP REDIRECT PROTECTION
+# ═══════════════════════════════════════════════════════════════════════════
+# Don't accept ICMP redirects (prevents route hijacking)
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+
+# Don't send ICMP redirects (we're a router, but shouldn't redirect)
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+
+# ═══════════════════════════════════════════════════════════════════════════
+# IP FORWARDING (Required for router functionality)
+# ═══════════════════════════════════════════════════════════════════════════
+net.ipv4.ip_forward = 1
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CONNTRACK TUNING (for high connection counts)
+# ═══════════════════════════════════════════════════════════════════════════
+# Increase maximum tracked connections (default is often 65536)
+net.netfilter.nf_conntrack_max = 262144
+
+# Reduce timeout for established TCP connections (default 432000 = 5 days)
+# 3600 seconds = 1 hour is reasonable for VPN traffic
+net.netfilter.nf_conntrack_tcp_timeout_established = 3600
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ADDITIONAL HARDENING
+# ═══════════════════════════════════════════════════════════════════════════
+# Ignore bogus ICMP error responses
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+# Don't respond to ICMP broadcasts (smurf attack prevention)
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+# Disable source routing (prevents IP source route attacks)
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+
+# TCP SYN cookies for SYN flood protection
+net.ipv4.tcp_syncookies = 1

--- a/scripts/router-peer/README.md
+++ b/scripts/router-peer/README.md
@@ -1,0 +1,134 @@
+# Router-Peer Defense-in-Depth Scripts
+
+Defense-in-depth hardening scripts for the NetBird Machine Tunnel router-peer.
+
+## Overview
+
+The router-peer is a Linux VM that routes traffic between the WireGuard mesh and the DC network. These scripts implement security hardening beyond the basic firewall rules.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `setup-hardening.sh` | Main setup script (run as root) |
+| `verify-hardening.sh` | Verification script |
+| `99-netbird-hardening.conf` | Sysctl kernel parameters |
+
+## Quick Start
+
+```bash
+# 1. Copy scripts to router-peer
+scp -r scripts/router-peer/ user@router-peer:/tmp/
+
+# 2. SSH to router-peer
+ssh user@router-peer
+
+# 3. Run setup (dry-run first!)
+cd /tmp/router-peer
+sudo ./setup-hardening.sh --dry-run
+
+# 4. Run setup for real
+sudo ./setup-hardening.sh
+
+# 5. Verify
+./verify-hardening.sh
+```
+
+## Security Layers
+
+### 1. Kernel Parameters (sysctl)
+
+| Parameter | Value | Protection |
+|-----------|-------|------------|
+| `rp_filter` | 1 | Anti-IP-spoofing (reverse path filtering) |
+| `log_martians` | 1 | Log impossible source addresses |
+| `accept_redirects` | 0 | Prevent ICMP route hijacking |
+| `send_redirects` | 0 | Don't send ICMP redirects |
+| `tcp_syncookies` | 1 | SYN flood protection |
+
+### 2. INPUT Chain (Protect Router Itself)
+
+- **Default Policy:** DROP
+- **Allowed:** Loopback, established connections, SSH (mgmt only), WireGuard (UDP 51820), ICMP (rate limited)
+- **Logging:** Dropped packets logged (rate limited)
+
+### 3. FORWARD Chain (Traffic Routing)
+
+- **Invalid Packets:** Dropped (prevents state confusion)
+- **SYN Flood:** Rate limited (100/sec, burst 200)
+- **Connection Limit:** 200 per source IP (prevents resource exhaustion)
+
+### 4. OUTPUT Chain
+
+- **Default Policy:** ACCEPT (router needs outbound)
+- **Logging:** Suspicious outbound to client network logged
+
+## Network Assumptions
+
+Default interface mapping (adjust in `setup-hardening.sh`):
+
+| Interface | Network | Purpose |
+|-----------|---------|---------|
+| eth0 | 10.0.0.0/24 | Management (SSH) |
+| eth1 | 192.168.100.0/24 | DC network (vmbr1) |
+| eth2 | 192.168.101.0/24 | Client network (vmbr2) |
+| wt0 | 100.64.0.0/10 | WireGuard tunnel |
+
+To customize:
+
+```bash
+MGMT_IFACE=ens3 DC_IFACE=ens4 CLIENT_IFACE=ens5 ./setup-hardening.sh
+```
+
+## Verification
+
+Run `verify-hardening.sh` to check all security measures:
+
+```bash
+./verify-hardening.sh
+```
+
+Expected output:
+```
+[PASS] net.ipv4.conf.all.rp_filter = 1
+[PASS] iptables INPUT policy: DROP
+[PASS] SYN flood protection
+...
+All checks passed! Router-peer is properly hardened.
+```
+
+## Troubleshooting
+
+### Locked out of SSH
+
+If you lose SSH access:
+
+1. Access via console (Proxmox, etc.)
+2. Flush iptables: `iptables -F && iptables -P INPUT ACCEPT`
+3. Fix configuration
+4. Re-run setup
+
+### Traffic not forwarding
+
+Check:
+1. `ip_forward` enabled: `cat /proc/sys/net/ipv4/ip_forward`
+2. FORWARD chain rules: `iptables -L FORWARD -v -n`
+3. Connection tracking: `conntrack -L | wc -l`
+
+### High connection count
+
+If conntrack table fills up:
+```bash
+# Check current usage
+cat /proc/sys/net/netfilter/nf_conntrack_count
+cat /proc/sys/net/netfilter/nf_conntrack_max
+
+# Increase if needed
+echo 524288 > /proc/sys/net/netfilter/nf_conntrack_max
+```
+
+## References
+
+- [Issue #25](https://github.com/obtFusi/netbird-fork/issues/25) - Task description
+- [iptables Tutorial](https://www.frozentux.net/iptables-tutorial/iptables-tutorial.html)
+- [Linux Kernel Networking Parameters](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt)

--- a/scripts/router-peer/setup-hardening.sh
+++ b/scripts/router-peer/setup-hardening.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# NetBird Router-Peer Defense-in-Depth Setup Script
+# This script configures iptables and kernel parameters for secure routing.
+#
+# Usage: sudo ./setup-hardening.sh [--dry-run]
+#
+# Prerequisites:
+# - Ubuntu 22.04 LTS or similar
+# - iptables and iptables-persistent installed
+# - NetBird WireGuard interface (wt0) configured
+#
+# Network assumptions (adjust as needed):
+# - eth0: Management network (SSH access)
+# - eth1: DC network (vmbr1 - 192.168.100.0/24)
+# - eth2: Client network (vmbr2 - 192.168.101.0/24)
+# - wt0: WireGuard tunnel interface (100.64.0.0/10)
+
+set -euo pipefail
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYSCTL_CONF="${SCRIPT_DIR}/99-netbird-hardening.conf"
+SYSCTL_DEST="/etc/sysctl.d/99-netbird-hardening.conf"
+
+# Interfaces (adjust for your environment)
+MGMT_IFACE="${MGMT_IFACE:-eth0}"
+DC_IFACE="${DC_IFACE:-eth1}"
+CLIENT_IFACE="${CLIENT_IFACE:-eth2}"
+WG_PORT="${WG_PORT:-51820}"
+
+# Rate limits
+SYN_RATE="100/sec"
+SYN_BURST="200"
+ICMP_RATE="10/sec"
+LOG_RATE="5/min"
+CONNLIMIT_PER_IP="200"
+
+DRY_RUN=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+run_cmd() {
+    if $DRY_RUN; then
+        echo "[DRY-RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+check_root() {
+    if [[ $EUID -ne 0 ]] && ! $DRY_RUN; then
+        echo "Error: This script must be run as root"
+        exit 1
+    fi
+}
+
+check_prerequisites() {
+    log "Checking prerequisites..."
+
+    local missing=()
+
+    if ! command -v iptables &>/dev/null; then
+        missing+=("iptables")
+    fi
+
+    if ! command -v netfilter-persistent &>/dev/null; then
+        missing+=("iptables-persistent")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Error: Missing packages: ${missing[*]}"
+        echo "Install with: apt-get install ${missing[*]}"
+        exit 1
+    fi
+
+    log "Prerequisites OK"
+}
+
+setup_sysctl() {
+    log "Setting up kernel parameters..."
+
+    if [[ ! -f "$SYSCTL_CONF" ]]; then
+        echo "Error: Sysctl config not found: $SYSCTL_CONF"
+        exit 1
+    fi
+
+    run_cmd cp "$SYSCTL_CONF" "$SYSCTL_DEST"
+    run_cmd sysctl -p "$SYSCTL_DEST"
+
+    log "Kernel parameters configured"
+}
+
+setup_input_chain() {
+    log "Configuring INPUT chain (protect router-peer itself)..."
+
+    # Set default policy to DROP
+    run_cmd iptables -P INPUT DROP
+
+    # Allow loopback
+    run_cmd iptables -A INPUT -i lo -j ACCEPT
+
+    # Allow established connections
+    run_cmd iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+    # Drop invalid packets early
+    run_cmd iptables -A INPUT -m state --state INVALID -j DROP
+
+    # SSH only from management interface
+    run_cmd iptables -A INPUT -i "$MGMT_IFACE" -p tcp --dport 22 -j ACCEPT
+
+    # NetBird WireGuard (UDP)
+    run_cmd iptables -A INPUT -p udp --dport "$WG_PORT" -j ACCEPT
+
+    # ICMP with rate limiting (for diagnostics)
+    run_cmd iptables -A INPUT -p icmp --icmp-type echo-request -m limit --limit "$ICMP_RATE" -j ACCEPT
+
+    # Log dropped packets (rate limited)
+    run_cmd iptables -A INPUT -m limit --limit "$LOG_RATE" -j LOG --log-prefix "INPUT-DROP: "
+
+    log "INPUT chain configured"
+}
+
+setup_forward_chain() {
+    log "Configuring FORWARD chain (traffic routing)..."
+
+    # Drop invalid packets first (prevents state confusion attacks)
+    run_cmd iptables -I FORWARD 1 -m state --state INVALID -j DROP
+
+    # SYN flood protection (rate limiting for new TCP connections)
+    run_cmd iptables -I FORWARD 2 -p tcp --syn -m limit --limit "$SYN_RATE" --limit-burst "$SYN_BURST" -j ACCEPT
+    run_cmd iptables -I FORWARD 3 -p tcp --syn -j DROP
+
+    # Connection limit per source IP (prevents resource exhaustion)
+    run_cmd iptables -I FORWARD 4 -p tcp -m connlimit --connlimit-above "$CONNLIMIT_PER_IP" --connlimit-mask 32 -j REJECT
+
+    # Allow established and related
+    run_cmd iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+    log "FORWARD chain configured"
+}
+
+setup_output_chain() {
+    log "Configuring OUTPUT chain (outbound traffic)..."
+
+    # Default ACCEPT (router needs outbound for NetBird)
+    run_cmd iptables -P OUTPUT ACCEPT
+
+    # Log suspicious outbound to client network (router should not initiate)
+    run_cmd iptables -A OUTPUT -o "$CLIENT_IFACE" -m state --state NEW -m limit --limit "$LOG_RATE" -j LOG --log-prefix "SUSPICIOUS-OUTPUT: "
+
+    log "OUTPUT chain configured"
+}
+
+save_rules() {
+    log "Saving iptables rules persistently..."
+    run_cmd netfilter-persistent save
+    log "Rules saved"
+}
+
+main() {
+    log "=== NetBird Router-Peer Defense-in-Depth Setup ==="
+
+    if $DRY_RUN; then
+        log "Running in DRY-RUN mode (no changes will be made)"
+    fi
+
+    check_root
+    check_prerequisites
+
+    log ""
+    log "Configuration:"
+    log "  Management interface: $MGMT_IFACE"
+    log "  DC interface: $DC_IFACE"
+    log "  Client interface: $CLIENT_IFACE"
+    log "  WireGuard port: $WG_PORT"
+    log ""
+
+    setup_sysctl
+    setup_input_chain
+    setup_forward_chain
+    setup_output_chain
+    save_rules
+
+    log ""
+    log "=== Setup Complete ==="
+    log "Run './verify-hardening.sh' to verify the configuration"
+}
+
+main "$@"

--- a/scripts/router-peer/verify-hardening.sh
+++ b/scripts/router-peer/verify-hardening.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# NetBird Router-Peer Defense-in-Depth Verification Script
+# Verifies that all hardening measures are properly configured.
+#
+# Usage: ./verify-hardening.sh
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASSED=0
+FAILED=0
+WARNINGS=0
+
+check_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    ((PASSED++))
+}
+
+check_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    ((FAILED++))
+}
+
+check_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+    ((WARNINGS++))
+}
+
+check_sysctl() {
+    local param=$1
+    local expected=$2
+    local actual
+
+    actual=$(cat "/proc/sys/${param//./\/}" 2>/dev/null || echo "NOT_FOUND")
+
+    if [[ "$actual" == "$expected" ]]; then
+        check_pass "$param = $expected"
+        return 0
+    else
+        check_fail "$param = $actual (expected: $expected)"
+        return 1
+    fi
+}
+
+check_iptables_policy() {
+    local chain=$1
+    local expected=$2
+    local actual
+
+    actual=$(iptables -L "$chain" -n 2>/dev/null | head -1 | grep -oP 'policy \K\w+' || echo "UNKNOWN")
+
+    if [[ "$actual" == "$expected" ]]; then
+        check_pass "iptables $chain policy: $expected"
+        return 0
+    else
+        check_fail "iptables $chain policy: $actual (expected: $expected)"
+        return 1
+    fi
+}
+
+check_iptables_rule() {
+    local description=$1
+    local grep_pattern=$2
+
+    if iptables-save 2>/dev/null | grep -qE "$grep_pattern"; then
+        check_pass "$description"
+        return 0
+    else
+        check_fail "$description"
+        return 1
+    fi
+}
+
+echo "═══════════════════════════════════════════════════════════════════════"
+echo " NetBird Router-Peer Defense-in-Depth Verification"
+echo "═══════════════════════════════════════════════════════════════════════"
+echo ""
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    echo -e "${YELLOW}Note: Running without root - some checks may fail${NC}"
+    echo ""
+fi
+
+echo "1. KERNEL PARAMETERS (sysctl)"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+# Anti-spoofing
+check_sysctl "net.ipv4.conf.all.rp_filter" "1"
+check_sysctl "net.ipv4.conf.default.rp_filter" "1"
+
+# Martian logging
+check_sysctl "net.ipv4.conf.all.log_martians" "1"
+check_sysctl "net.ipv4.conf.default.log_martians" "1"
+
+# ICMP redirects
+check_sysctl "net.ipv4.conf.all.accept_redirects" "0"
+check_sysctl "net.ipv4.conf.all.send_redirects" "0"
+
+# IP forwarding (required for router)
+check_sysctl "net.ipv4.ip_forward" "1"
+
+# Conntrack tuning
+conntrack_max=$(cat /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null || echo "0")
+if [[ "$conntrack_max" -ge 262144 ]]; then
+    check_pass "nf_conntrack_max >= 262144 (actual: $conntrack_max)"
+else
+    check_warn "nf_conntrack_max = $conntrack_max (recommended: >= 262144)"
+fi
+
+echo ""
+echo "2. IPTABLES INPUT CHAIN"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+check_iptables_policy "INPUT" "DROP"
+check_iptables_rule "Loopback allowed" "-A INPUT -i lo -j ACCEPT"
+check_iptables_rule "Established connections allowed" "-A INPUT .* --state ESTABLISHED,RELATED -j ACCEPT"
+check_iptables_rule "Invalid packets dropped" "-A INPUT .* --state INVALID -j DROP"
+check_iptables_rule "SSH allowed (port 22)" "-A INPUT .* --dport 22 -j ACCEPT"
+check_iptables_rule "WireGuard allowed (UDP 51820)" "-A INPUT .* --dport 51820 -j ACCEPT"
+check_iptables_rule "ICMP rate limited" "-A INPUT .* icmp .* --limit .* -j ACCEPT"
+
+echo ""
+echo "3. IPTABLES FORWARD CHAIN"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+check_iptables_rule "Invalid packets dropped in FORWARD" "-A FORWARD .* --state INVALID -j DROP"
+check_iptables_rule "SYN flood protection" "-A FORWARD .* --tcp-flags .* SYN .* --limit"
+check_iptables_rule "Connection limit per IP" "-A FORWARD .* connlimit"
+
+echo ""
+echo "4. IPTABLES OUTPUT CHAIN"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+check_iptables_policy "OUTPUT" "ACCEPT"
+# OUTPUT logging is optional, just check policy
+
+echo ""
+echo "5. PERSISTENT RULES"
+echo "─────────────────────────────────────────────────────────────────────────"
+
+if [[ -f /etc/iptables/rules.v4 ]]; then
+    check_pass "Persistent rules file exists: /etc/iptables/rules.v4"
+else
+    check_warn "Persistent rules file not found (rules may not survive reboot)"
+fi
+
+if [[ -f /etc/sysctl.d/99-netbird-hardening.conf ]]; then
+    check_pass "Sysctl config installed: /etc/sysctl.d/99-netbird-hardening.conf"
+else
+    check_fail "Sysctl config not found: /etc/sysctl.d/99-netbird-hardening.conf"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════"
+echo " SUMMARY"
+echo "═══════════════════════════════════════════════════════════════════════"
+echo -e "  ${GREEN}Passed:${NC}   $PASSED"
+echo -e "  ${RED}Failed:${NC}   $FAILED"
+echo -e "  ${YELLOW}Warnings:${NC} $WARNINGS"
+echo ""
+
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "${RED}Some checks failed. Run 'sudo ./setup-hardening.sh' to fix.${NC}"
+    exit 1
+elif [[ $WARNINGS -gt 0 ]]; then
+    echo -e "${YELLOW}All critical checks passed with some warnings.${NC}"
+    exit 0
+else
+    echo -e "${GREEN}All checks passed! Router-peer is properly hardened.${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Describe your changes
Add router-peer defense-in-depth hardening scripts (Issue #25).

- Kernel hardening via sysctl (anti-spoofing, ICMP protection)
- iptables INPUT/FORWARD/OUTPUT chain hardening
- Verification script for all security measures

## Issue ticket number and link
Closes #25

### Checklist
- [x] Is a feature enhancement
- [ ] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [x] Documentation is **not needed** for this change (explain why)

Scripts for Lab setup, not user-facing feature. README included in scripts/router-peer/.

## Test plan
- [ ] Deploy to router-peer VM
- [ ] Run `./setup-hardening.sh --dry-run`
- [ ] Run `./setup-hardening.sh`
- [ ] Verify with `./verify-hardening.sh`

🤖 Generated with [Claude Code](https://claude.ai/code)