### PR TITLE
feat(build): Add multi-stage Dockerfile for management server

### DIFF
--- a/management/Dockerfile.multistage
+++ b/management/Dockerfile.multistage
@@ -1,0 +1,13 @@
+FROM golang:1.25 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -ldflags="-s -w" -o /netbird-mgmt ./management/
+
+FROM ubuntu:24.04
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /netbird-mgmt /go/bin/netbird-mgmt
+RUN chmod +x /go/bin/netbird-mgmt
+ENTRYPOINT ["/go/bin/netbird-mgmt", "management"]
+CMD ["--log-file", "console"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile for management server build
- Fixes ar archive issue when building inside container
- Uses golang:1.25 builder + ubuntu:24.04 runtime

## Test plan
- [x] Build produces ELF binary (not ar archive)
- [x] Binary runs correctly (--help works)
- [x] Docker image deploys successfully

## Documentation
- [x] Documentation is **not needed** (internal build tooling only)

---
Generated with [Claude Code](https://claude.com/claude-code)