### PR TITLE
feat(client): Add machine tunnel bootstrap and domain join (T-5.1, T-5.2)

### DIFF
--- a/client/internal/tunnel/bootstrap.go
+++ b/client/internal/tunnel/bootstrap.go
@@ -1,0 +1,470 @@
+// Package tunnel provides machine tunnel functionality for Windows pre-login VPN.
+// This package handles the two-phase bootstrap process:
+// Phase 1: Setup-Key authentication (for initial enrollment)
+// Phase 2: mTLS authentication (after AD CS certificate enrollment)
+package tunnel
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
+	"github.com/netbirdio/netbird/client/ssh"
+	"github.com/netbirdio/netbird/client/system"
+	mgm "github.com/netbirdio/netbird/shared/management/client"
+	mgmProto "github.com/netbirdio/netbird/shared/management/proto"
+)
+
+// infoToProtoMeta converts system.Info to proto.PeerSystemMeta for gRPC requests.
+func infoToProtoMeta(info *system.Info) *mgmProto.PeerSystemMeta {
+	if info == nil {
+		return nil
+	}
+
+	addresses := make([]*mgmProto.NetworkAddress, 0, len(info.NetworkAddresses))
+	for _, addr := range info.NetworkAddresses {
+		addresses = append(addresses, &mgmProto.NetworkAddress{
+			NetIP: addr.NetIP.String(),
+			Mac:   addr.Mac,
+		})
+	}
+
+	files := make([]*mgmProto.File, 0, len(info.Files))
+	for _, file := range info.Files {
+		files = append(files, &mgmProto.File{
+			Path:             file.Path,
+			Exist:            file.Exist,
+			ProcessIsRunning: file.ProcessIsRunning,
+		})
+	}
+
+	return &mgmProto.PeerSystemMeta{
+		Hostname:         info.Hostname,
+		GoOS:             info.GoOS,
+		OS:               info.OS,
+		Core:             info.OSVersion,
+		OSVersion:        info.OSVersion,
+		Platform:         info.Platform,
+		Kernel:           info.Kernel,
+		NetbirdVersion:   info.NetbirdVersion,
+		UiVersion:        info.UIVersion,
+		KernelVersion:    info.KernelVersion,
+		NetworkAddresses: addresses,
+		SysSerialNumber:  info.SystemSerialNumber,
+		SysManufacturer:  info.SystemManufacturer,
+		SysProductName:   info.SystemProductName,
+		Environment: &mgmProto.Environment{
+			Cloud:    info.Environment.Cloud,
+			Platform: info.Environment.Platform,
+		},
+		Files: files,
+		Flags: &mgmProto.Flags{
+			RosenpassEnabled:              info.RosenpassEnabled,
+			RosenpassPermissive:           info.RosenpassPermissive,
+			ServerSSHAllowed:              info.ServerSSHAllowed,
+			DisableClientRoutes:           info.DisableClientRoutes,
+			DisableServerRoutes:           info.DisableServerRoutes,
+			DisableDNS:                    info.DisableDNS,
+			DisableFirewall:               info.DisableFirewall,
+			BlockLANAccess:                info.BlockLANAccess,
+			BlockInbound:                  info.BlockInbound,
+			LazyConnectionEnabled:         info.LazyConnectionEnabled,
+			EnableSSHRoot:                 info.EnableSSHRoot,
+			EnableSSHSFTP:                 info.EnableSSHSFTP,
+			EnableSSHLocalPortForwarding:  info.EnableSSHLocalPortForwarding,
+			EnableSSHRemotePortForwarding: info.EnableSSHRemotePortForwarding,
+			DisableSSHAuth:                info.DisableSSHAuth,
+		},
+	}
+}
+
+// AuthMethod indicates which authentication method was used for bootstrap.
+type AuthMethod int
+
+const (
+	// AuthMethodUnknown indicates no authentication method was determined.
+	AuthMethodUnknown AuthMethod = iota
+	// AuthMethodSetupKey indicates Setup-Key was used (Phase 1).
+	AuthMethodSetupKey
+	// AuthMethodMTLS indicates mTLS with machine certificate was used (Phase 2).
+	AuthMethodMTLS
+)
+
+func (m AuthMethod) String() string {
+	switch m {
+	case AuthMethodSetupKey:
+		return "SetupKey"
+	case AuthMethodMTLS:
+		return "mTLS"
+	default:
+		return "Unknown"
+	}
+}
+
+// BootstrapResult contains the result of the bootstrap process.
+type BootstrapResult struct {
+	// AuthMethod indicates which authentication was used.
+	AuthMethod AuthMethod
+
+	// PeerConfig is the local peer configuration from the server.
+	PeerConfig *mgmProto.PeerConfig
+
+	// NetbirdConfig contains STUN/TURN/Relay configuration.
+	NetbirdConfig *mgmProto.NetbirdConfig
+
+	// MachineIdentity is present only for mTLS auth (Phase 2).
+	MachineIdentity *mgmProto.MachineIdentity
+
+	// AllowedDCRoutes are routes this machine can access (mTLS only).
+	AllowedDCRoutes []*mgmProto.Route
+
+	// DNSConfig for DC DNS resolution (mTLS only).
+	DNSConfig *mgmProto.DNSConfig
+}
+
+// MachineConfig extends the standard Config with machine tunnel specific settings.
+type MachineConfig struct {
+	// Embed standard config
+	*profilemanager.Config
+
+	// MachineCertEnabled indicates whether to use machine certificate authentication.
+	MachineCertEnabled bool
+
+	// MachineCertThumbprint is the expected certificate thumbprint (optional validation).
+	MachineCertThumbprint string
+
+	// SetupKey for Phase 1 bootstrap (one-time use, should be revoked after Phase 2).
+	SetupKey string
+
+	// MTLSPort is the port for mTLS connections (default: 33074).
+	MTLSPort int
+
+	// DCRoutes are the Domain Controller network CIDRs to route through the tunnel.
+	DCRoutes []string
+}
+
+// DefaultMTLSPort is the default port for mTLS machine tunnel connections.
+const DefaultMTLSPort = 33074
+
+// Bootstrap initiates the machine tunnel authentication process.
+// It automatically selects the appropriate authentication method:
+// - If a valid machine certificate is available, uses mTLS (Phase 2)
+// - Otherwise, falls back to Setup-Key authentication (Phase 1)
+//
+// After successful Setup-Key bootstrap, the client should:
+// 1. Join the domain (if not already joined)
+// 2. Enroll a machine certificate via AD CS
+// 3. Update config to enable machine cert (MachineCertEnabled = true)
+// 4. Restart the service to switch to mTLS auth
+func Bootstrap(ctx context.Context, cfg *MachineConfig) (*BootstrapResult, error) {
+	if cfg == nil || cfg.Config == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+
+	// Check if machine certificate is available and enabled
+	if cfg.MachineCertEnabled && hasMachineCert(cfg) {
+		log.Info("Machine certificate available, attempting mTLS authentication (Phase 2)")
+		result, err := bootstrapWithMTLS(ctx, cfg)
+		if err != nil {
+			// If mTLS fails and we have a setup key, fall back to Phase 1
+			if cfg.SetupKey != "" {
+				log.Warnf("mTLS authentication failed: %v, falling back to Setup-Key", err)
+				return bootstrapWithSetupKey(ctx, cfg)
+			}
+			return nil, fmt.Errorf("mTLS authentication failed: %w", err)
+		}
+		return result, nil
+	}
+
+	// No machine cert or not enabled - use Setup-Key (Phase 1)
+	if cfg.SetupKey == "" {
+		return nil, fmt.Errorf("no machine certificate available and no setup key provided; " +
+			"for initial bootstrap, provide a setup key")
+	}
+
+	log.Info("No machine certificate, using Setup-Key authentication (Phase 1)")
+	return bootstrapWithSetupKey(ctx, cfg)
+}
+
+// hasMachineCert checks if a valid machine certificate is configured and loadable.
+func hasMachineCert(cfg *MachineConfig) bool {
+	if cfg.ClientCertPath == "" || cfg.ClientCertKeyPath == "" {
+		log.Debug("Machine cert paths not configured")
+		return false
+	}
+
+	// Try to load the certificate
+	cert, err := tls.LoadX509KeyPair(cfg.ClientCertPath, cfg.ClientCertKeyPath)
+	if err != nil {
+		log.Debugf("Failed to load machine certificate: %v", err)
+		return false
+	}
+
+	// Parse to check validity
+	if len(cert.Certificate) == 0 {
+		log.Debug("No certificate in loaded key pair")
+		return false
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		log.Debugf("Failed to parse machine certificate: %v", err)
+		return false
+	}
+
+	// Check expiry
+	now := time.Now()
+	if now.Before(x509Cert.NotBefore) {
+		log.Debugf("Machine certificate not yet valid (NotBefore: %v)", x509Cert.NotBefore)
+		return false
+	}
+	if now.After(x509Cert.NotAfter) {
+		log.Debugf("Machine certificate expired (NotAfter: %v)", x509Cert.NotAfter)
+		return false
+	}
+
+	// Check for required SAN DNSName
+	if len(x509Cert.DNSNames) == 0 {
+		log.Debug("Machine certificate has no SAN DNSNames")
+		return false
+	}
+
+	// Validate thumbprint if specified
+	if cfg.MachineCertThumbprint != "" {
+		actualThumbprint := fmt.Sprintf("%x", sha256.Sum256(cert.Certificate[0]))
+		if !strings.EqualFold(actualThumbprint, cfg.MachineCertThumbprint) {
+			log.Debugf("Machine certificate thumbprint mismatch: expected %s, got %s",
+				cfg.MachineCertThumbprint, actualThumbprint)
+			return false
+		}
+	}
+
+	log.Debugf("Machine certificate valid: DNSNames=%v, NotAfter=%v", x509Cert.DNSNames, x509Cert.NotAfter)
+	return true
+}
+
+// bootstrapWithSetupKey performs Phase 1 bootstrap using a Setup-Key.
+// This uses the standard Login/Register RPC (not RegisterMachinePeer).
+func bootstrapWithSetupKey(ctx context.Context, cfg *MachineConfig) (*BootstrapResult, error) {
+	// Validate setup key format
+	if _, err := uuid.Parse(cfg.SetupKey); err != nil {
+		return nil, fmt.Errorf("invalid setup key format: %w", err)
+	}
+
+	log.Debugf("Connecting to management server %s with Setup-Key", cfg.ManagementURL)
+
+	// Create standard management client (not mTLS)
+	mgmClient, err := getMgmClient(ctx, cfg.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to management server: %w", err)
+	}
+	defer func() {
+		if closeErr := mgmClient.Close(); closeErr != nil {
+			log.Warnf("Failed to close management client: %v", closeErr)
+		}
+	}()
+
+	// Get server public key
+	serverKey, err := mgmClient.GetServerPublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get server public key: %w", err)
+	}
+
+	// Generate SSH key for registration
+	pubSSHKey, err := ssh.GeneratePublicKey([]byte(cfg.SSHKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate SSH public key: %w", err)
+	}
+
+	// Try to login first (peer might already be registered)
+	sysInfo := system.GetInfo(ctx)
+	setSystemFlags(sysInfo, cfg.Config)
+
+	loginResp, err := mgmClient.Login(*serverKey, sysInfo, pubSSHKey, cfg.DNSLabels)
+	if err == nil {
+		// Already registered, login successful
+		log.Info("Setup-Key bootstrap: peer already registered, login successful")
+		return &BootstrapResult{
+			AuthMethod:    AuthMethodSetupKey,
+			PeerConfig:    loginResp.PeerConfig,
+			NetbirdConfig: loginResp.NetbirdConfig,
+		}, nil
+	}
+
+	// Check if registration is needed
+	if !isRegistrationNeeded(err) {
+		return nil, fmt.Errorf("login failed: %w", err)
+	}
+
+	// Register new peer with setup key
+	log.Debug("Peer not registered, registering with Setup-Key")
+	loginResp, err = mgmClient.Register(*serverKey, cfg.SetupKey, "", sysInfo, pubSSHKey, cfg.DNSLabels)
+	if err != nil {
+		return nil, fmt.Errorf("registration with setup key failed: %w", err)
+	}
+
+	log.Info("Setup-Key bootstrap: peer registered successfully")
+	return &BootstrapResult{
+		AuthMethod:    AuthMethodSetupKey,
+		PeerConfig:    loginResp.PeerConfig,
+		NetbirdConfig: loginResp.NetbirdConfig,
+	}, nil
+}
+
+// bootstrapWithMTLS performs Phase 2 bootstrap using mTLS with machine certificate.
+// This uses the RegisterMachinePeer RPC which is mTLS-only.
+func bootstrapWithMTLS(ctx context.Context, cfg *MachineConfig) (*BootstrapResult, error) {
+	// Determine mTLS port
+	mtlsPort := cfg.MTLSPort
+	if mtlsPort == 0 {
+		mtlsPort = DefaultMTLSPort
+	}
+
+	// Build mTLS URL
+	mtlsURL, err := buildMTLSURL(cfg.ManagementURL, mtlsPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build mTLS URL: %w", err)
+	}
+
+	log.Debugf("Connecting to management server %s with mTLS", mtlsURL)
+
+	// Load client certificate
+	cert, err := tls.LoadX509KeyPair(cfg.ClientCertPath, cfg.ClientCertKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load machine certificate: %w", err)
+	}
+
+	// Create TLS config with client certificate
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create gRPC connection with mTLS
+	creds := credentials.NewTLS(tlsConfig)
+	conn, err := grpc.DialContext(ctx, mtlsURL,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect with mTLS: %w", err)
+	}
+	defer conn.Close()
+
+	// Create management service client
+	client := mgmProto.NewManagementServiceClient(conn)
+
+	// Generate WireGuard key for this machine tunnel
+	wgKey, err := wgtypes.GenerateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate WireGuard key: %w", err)
+	}
+
+	// Get system info
+	sysInfo := system.GetInfo(ctx)
+	setSystemFlags(sysInfo, cfg.Config)
+
+	// Build registration request
+	// Note: The machine identity is extracted from the mTLS certificate by the server,
+	// we don't need to send it explicitly
+	req := &mgmProto.MachineRegisterRequest{
+		Meta:     infoToProtoMeta(sysInfo),
+		WgPubKey: []byte(wgKey.PublicKey().String()),
+	}
+
+	// Call RegisterMachinePeer RPC
+	resp, err := client.RegisterMachinePeer(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("RegisterMachinePeer failed: %w", err)
+	}
+
+	log.Infof("mTLS bootstrap successful: identity=%s", resp.MachineIdentity.DnsName)
+
+	return &BootstrapResult{
+		AuthMethod:      AuthMethodMTLS,
+		PeerConfig:      resp.PeerConfig,
+		NetbirdConfig:   resp.NetbirdConfig,
+		MachineIdentity: resp.MachineIdentity,
+		AllowedDCRoutes: resp.AllowedDcRoutes,
+		DNSConfig:       resp.DnsConfig,
+	}, nil
+}
+
+// getMgmClient creates a standard management gRPC client.
+func getMgmClient(ctx context.Context, config *profilemanager.Config) (*mgm.GrpcClient, error) {
+	myPrivateKey, err := wgtypes.ParseKey(config.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse WireGuard private key: %w", err)
+	}
+
+	tlsEnabled := config.ManagementURL.Scheme == "https"
+
+	client, err := mgm.NewClient(ctx, config.ManagementURL.Host, myPrivateKey, tlsEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create management client: %w", err)
+	}
+
+	return client, nil
+}
+
+// buildMTLSURL constructs the mTLS endpoint URL from the management URL.
+func buildMTLSURL(mgmURL *url.URL, mtlsPort int) (string, error) {
+	if mgmURL == nil {
+		return "", fmt.Errorf("management URL is nil")
+	}
+
+	// Extract host without port
+	host := mgmURL.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("empty host in management URL")
+	}
+
+	return fmt.Sprintf("%s:%d", host, mtlsPort), nil
+}
+
+// setSystemFlags sets the system flags from config.
+func setSystemFlags(sysInfo *system.Info, config *profilemanager.Config) {
+	sysInfo.SetFlags(
+		config.RosenpassEnabled,
+		config.RosenpassPermissive,
+		config.ServerSSHAllowed,
+		config.DisableClientRoutes,
+		config.DisableServerRoutes,
+		config.DisableDNS,
+		config.DisableFirewall,
+		config.BlockLANAccess,
+		config.BlockInbound,
+		config.LazyConnectionEnabled,
+		config.EnableSSHRoot,
+		config.EnableSSHSFTP,
+		config.EnableSSHLocalPortForwarding,
+		config.EnableSSHRemotePortForwarding,
+		config.DisableSSHAuth,
+	)
+}
+
+// isRegistrationNeeded checks if the error indicates that peer registration is required.
+func isRegistrationNeeded(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return s.Code() == codes.PermissionDenied
+}

--- a/client/internal/tunnel/bootstrap_test.go
+++ b/client/internal/tunnel/bootstrap_test.go
@@ -1,0 +1,319 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netbirdio/netbird/client/internal/profilemanager"
+)
+
+func TestAuthMethodString(t *testing.T) {
+	tests := []struct {
+		method   AuthMethod
+		expected string
+	}{
+		{AuthMethodUnknown, "Unknown"},
+		{AuthMethodSetupKey, "SetupKey"},
+		{AuthMethodMTLS, "mTLS"},
+		{AuthMethod(99), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.method.String())
+		})
+	}
+}
+
+func TestHasMachineCert_NoPaths(t *testing.T) {
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    "",
+			ClientCertKeyPath: "",
+		},
+	}
+
+	assert.False(t, hasMachineCert(cfg))
+}
+
+func TestHasMachineCert_InvalidPath(t *testing.T) {
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    "/nonexistent/cert.pem",
+			ClientCertKeyPath: "/nonexistent/key.pem",
+		},
+	}
+
+	assert.False(t, hasMachineCert(cfg))
+}
+
+func TestHasMachineCert_ValidCert(t *testing.T) {
+	// Create a temporary directory for test certificates
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	// Generate a test certificate with SAN DNSName
+	err := generateTestCertificate(certPath, keyPath, []string{"test-machine.corp.local"}, time.Hour)
+	require.NoError(t, err)
+
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    certPath,
+			ClientCertKeyPath: keyPath,
+		},
+	}
+
+	assert.True(t, hasMachineCert(cfg))
+}
+
+func TestHasMachineCert_ExpiredCert(t *testing.T) {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	// Generate an expired certificate (valid for -1 hour, i.e., already expired)
+	err := generateTestCertificateWithTimes(certPath, keyPath, []string{"test-machine.corp.local"},
+		time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour))
+	require.NoError(t, err)
+
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    certPath,
+			ClientCertKeyPath: keyPath,
+		},
+	}
+
+	assert.False(t, hasMachineCert(cfg))
+}
+
+func TestHasMachineCert_NoDNSNames(t *testing.T) {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	// Generate a certificate without SAN DNSNames
+	err := generateTestCertificate(certPath, keyPath, nil, time.Hour)
+	require.NoError(t, err)
+
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    certPath,
+			ClientCertKeyPath: keyPath,
+		},
+	}
+
+	assert.False(t, hasMachineCert(cfg))
+}
+
+func TestHasMachineCert_ThumbprintMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	err := generateTestCertificate(certPath, keyPath, []string{"test-machine.corp.local"}, time.Hour)
+	require.NoError(t, err)
+
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    certPath,
+			ClientCertKeyPath: keyPath,
+		},
+		MachineCertThumbprint: "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	assert.False(t, hasMachineCert(cfg))
+}
+
+func TestBuildMTLSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		mgmURL    string
+		mtlsPort  int
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "standard URL",
+			mgmURL:   "https://api.netbird.io:443",
+			mtlsPort: 33074,
+			expected: "api.netbird.io:33074",
+		},
+		{
+			name:     "URL without port",
+			mgmURL:   "https://api.netbird.io",
+			mtlsPort: 33074,
+			expected: "api.netbird.io:33074",
+		},
+		{
+			name:     "localhost",
+			mgmURL:   "https://localhost:33073",
+			mtlsPort: 33074,
+			expected: "localhost:33074",
+		},
+		{
+			name:     "IP address",
+			mgmURL:   "https://192.168.1.100:443",
+			mtlsPort: 33074,
+			expected: "192.168.1.100:33074",
+		},
+		{
+			name:     "custom port",
+			mgmURL:   "https://mgmt.example.com:8443",
+			mtlsPort: 8444,
+			expected: "mgmt.example.com:8444",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.mgmURL)
+			require.NoError(t, err)
+
+			result, err := buildMTLSURL(u, tt.mtlsPort)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildMTLSURL_NilURL(t *testing.T) {
+	_, err := buildMTLSURL(nil, 33074)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestBootstrap_NilConfig(t *testing.T) {
+	ctx := context.Background()
+	_, err := Bootstrap(ctx, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "config is required")
+}
+
+func TestBootstrap_NilEmbeddedConfig(t *testing.T) {
+	ctx := context.Background()
+	cfg := &MachineConfig{Config: nil}
+	_, err := Bootstrap(ctx, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "config is required")
+}
+
+func TestBootstrap_NoSetupKeyNoCert(t *testing.T) {
+	ctx := context.Background()
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    "",
+			ClientCertKeyPath: "",
+		},
+		SetupKey: "",
+	}
+	_, err := Bootstrap(ctx, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no machine certificate available and no setup key provided")
+}
+
+func TestBootstrapWithSetupKey_InvalidSetupKey(t *testing.T) {
+	ctx := context.Background()
+	cfg := &MachineConfig{
+		Config: &profilemanager.Config{
+			ClientCertPath:    "",
+			ClientCertKeyPath: "",
+		},
+		SetupKey: "not-a-uuid",
+	}
+	_, err := bootstrapWithSetupKey(ctx, cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid setup key format")
+}
+
+func TestDefaultMTLSPort(t *testing.T) {
+	assert.Equal(t, 33074, DefaultMTLSPort)
+}
+
+// Helper function to generate a test certificate
+func generateTestCertificate(certPath, keyPath string, dnsNames []string, validity time.Duration) error {
+	return generateTestCertificateWithTimes(certPath, keyPath, dnsNames,
+		time.Now().Add(-time.Hour), time.Now().Add(validity))
+}
+
+func generateTestCertificateWithTimes(certPath, keyPath string, dnsNames []string, notBefore, notAfter time.Time) error {
+	// Generate ECDSA key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	// Create certificate template
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Test Machine",
+			Organization: []string{"Test Org"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              dnsNames,
+	}
+
+	// Self-sign the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	// Write certificate
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return fmt.Errorf("failed to create cert file: %w", err)
+	}
+	defer certFile.Close()
+
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return fmt.Errorf("failed to encode certificate: %w", err)
+	}
+
+	// Write private key
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to create key file: %w", err)
+	}
+	defer keyFile.Close()
+
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return fmt.Errorf("failed to encode private key: %w", err)
+	}
+
+	return nil
+}

--- a/client/internal/tunnel/domainjoin.go
+++ b/client/internal/tunnel/domainjoin.go
@@ -1,0 +1,342 @@
+// Package tunnel provides machine tunnel functionality for Windows pre-login VPN.
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DCConnectivityResult contains the results of DC connectivity checks.
+type DCConnectivityResult struct {
+	// DCAddress is the IP or hostname of the Domain Controller.
+	DCAddress string
+
+	// LDAPReachable indicates if LDAP (port 389) is reachable.
+	LDAPReachable bool
+
+	// LDAPSReachable indicates if LDAPS (port 636) is reachable.
+	LDAPSReachable bool
+
+	// KerberosReachable indicates if Kerberos (port 88) is reachable.
+	KerberosReachable bool
+
+	// DNSReachable indicates if DNS (port 53) is reachable.
+	DNSReachable bool
+
+	// SMBReachable indicates if SMB (port 445) is reachable for Sysvol/GPO.
+	SMBReachable bool
+
+	// NTPReachable indicates if NTP (port 123 UDP) is reachable.
+	NTPReachable bool
+
+	// AllRequired indicates if all required ports are reachable.
+	AllRequired bool
+
+	// Errors contains any errors encountered during checks.
+	Errors []string
+}
+
+// Required ports for Domain Controller connectivity.
+const (
+	PortLDAP     = 389
+	PortLDAPS    = 636
+	PortKerberos = 88
+	PortDNS      = 53
+	PortSMB      = 445
+	PortNTP      = 123
+	PortRPCEPM   = 135 // RPC Endpoint Mapper
+)
+
+// DefaultDCPorts are the ports required for basic DC connectivity.
+var DefaultDCPorts = []int{PortLDAP, PortKerberos, PortDNS}
+
+// DefaultConnectTimeout is the default timeout for TCP connection tests.
+const DefaultConnectTimeout = 5 * time.Second
+
+// MaxKerberosTimeSkew is the maximum allowed time skew for Kerberos (5 minutes).
+const MaxKerberosTimeSkew = 5 * time.Minute
+
+// CheckDCConnectivity verifies that the Domain Controller is reachable via the tunnel.
+// This should be called after the tunnel is established and before domain join.
+func CheckDCConnectivity(ctx context.Context, dcAddress string, timeout time.Duration) *DCConnectivityResult {
+	if timeout == 0 {
+		timeout = DefaultConnectTimeout
+	}
+
+	result := &DCConnectivityResult{
+		DCAddress: dcAddress,
+		Errors:    make([]string, 0),
+	}
+
+	log.Infof("Checking DC connectivity to %s", dcAddress)
+
+	// Check LDAP (TCP 389) - Required
+	result.LDAPReachable = checkTCPPort(ctx, dcAddress, PortLDAP, timeout)
+	if !result.LDAPReachable {
+		result.Errors = append(result.Errors, fmt.Sprintf("LDAP (port %d) not reachable", PortLDAP))
+	}
+
+	// Check Kerberos (TCP 88) - Required
+	result.KerberosReachable = checkTCPPort(ctx, dcAddress, PortKerberos, timeout)
+	if !result.KerberosReachable {
+		result.Errors = append(result.Errors, fmt.Sprintf("Kerberos (port %d) not reachable", PortKerberos))
+	}
+
+	// Check DNS (TCP 53) - Required
+	result.DNSReachable = checkTCPPort(ctx, dcAddress, PortDNS, timeout)
+	if !result.DNSReachable {
+		result.Errors = append(result.Errors, fmt.Sprintf("DNS (port %d) not reachable", PortDNS))
+	}
+
+	// Check LDAPS (TCP 636) - Optional
+	result.LDAPSReachable = checkTCPPort(ctx, dcAddress, PortLDAPS, timeout)
+
+	// Check SMB (TCP 445) - Optional but recommended for GPO
+	result.SMBReachable = checkTCPPort(ctx, dcAddress, PortSMB, timeout)
+
+	// Check NTP (UDP 123) - Important for Kerberos time sync
+	result.NTPReachable = checkUDPPort(ctx, dcAddress, PortNTP, timeout)
+	if !result.NTPReachable {
+		// NTP failure is a warning, not an error - time sync might work via other means
+		log.Warnf("NTP (port %d) not reachable - ensure time is synchronized", PortNTP)
+	}
+
+	// All required = LDAP + Kerberos + DNS
+	result.AllRequired = result.LDAPReachable && result.KerberosReachable && result.DNSReachable
+
+	if result.AllRequired {
+		log.Infof("DC connectivity check passed: all required ports reachable")
+	} else {
+		log.Errorf("DC connectivity check failed: %v", result.Errors)
+	}
+
+	return result
+}
+
+// checkTCPPort tests if a TCP port is reachable.
+func checkTCPPort(ctx context.Context, host string, port int, timeout time.Duration) bool {
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	// Create dialer with timeout
+	dialer := &net.Dialer{
+		Timeout: timeout,
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		log.Debugf("TCP port check failed: %s - %v", addr, err)
+		return false
+	}
+	defer conn.Close()
+
+	log.Debugf("TCP port check passed: %s", addr)
+	return true
+}
+
+// checkUDPPort tests if a UDP port is reachable (best effort - UDP is connectionless).
+// This sends a small packet and checks if there's no immediate ICMP unreachable.
+func checkUDPPort(ctx context.Context, host string, port int, timeout time.Duration) bool {
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	conn, err := net.DialTimeout("udp", addr, timeout)
+	if err != nil {
+		log.Debugf("UDP port check failed: %s - %v", addr, err)
+		return false
+	}
+	defer conn.Close()
+
+	// For NTP, send a basic NTP request to check if the service responds
+	if port == PortNTP {
+		return checkNTPService(conn, timeout)
+	}
+
+	// For other UDP services, just check if we could create the connection
+	log.Debugf("UDP port check passed (connection established): %s", addr)
+	return true
+}
+
+// checkNTPService sends a basic NTP request and checks for a response.
+func checkNTPService(conn net.Conn, timeout time.Duration) bool {
+	// NTP v3 request packet (minimal)
+	// Li=0, VN=3, Mode=3 (client), Stratum=0, Poll=0, Precision=0
+	ntpRequest := make([]byte, 48)
+	ntpRequest[0] = 0x1B // LI=0, VN=3, Mode=3
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		log.Debugf("Failed to set NTP deadline: %v", err)
+		return false
+	}
+
+	if _, err := conn.Write(ntpRequest); err != nil {
+		log.Debugf("Failed to send NTP request: %v", err)
+		return false
+	}
+
+	response := make([]byte, 48)
+	n, err := conn.Read(response)
+	if err != nil {
+		log.Debugf("No NTP response: %v", err)
+		return false
+	}
+
+	if n < 48 {
+		log.Debugf("Invalid NTP response size: %d", n)
+		return false
+	}
+
+	log.Debug("NTP service check passed")
+	return true
+}
+
+// PreJoinChecklist contains all pre-domain-join validation results.
+type PreJoinChecklist struct {
+	// DCConnectivity is the DC connectivity check result.
+	DCConnectivity *DCConnectivityResult
+
+	// TunnelUp indicates if the VPN tunnel is established.
+	TunnelUp bool
+
+	// TimeInSync indicates if system time is within Kerberos tolerance.
+	TimeInSync bool
+
+	// ReadyForJoin indicates if all checks pass and domain join can proceed.
+	ReadyForJoin bool
+
+	// Errors contains any blocking errors.
+	Errors []string
+
+	// Warnings contains non-blocking warnings.
+	Warnings []string
+}
+
+// ValidatePreJoinRequirements performs all checks required before domain join.
+func ValidatePreJoinRequirements(ctx context.Context, dcAddress string, tunnelUp bool) *PreJoinChecklist {
+	checklist := &PreJoinChecklist{
+		TunnelUp: tunnelUp,
+		Errors:   make([]string, 0),
+		Warnings: make([]string, 0),
+	}
+
+	// Check 1: Tunnel must be up
+	if !tunnelUp {
+		checklist.Errors = append(checklist.Errors, "VPN tunnel is not established")
+		checklist.ReadyForJoin = false
+		return checklist
+	}
+
+	// Check 2: DC connectivity
+	checklist.DCConnectivity = CheckDCConnectivity(ctx, dcAddress, DefaultConnectTimeout)
+	if !checklist.DCConnectivity.AllRequired {
+		checklist.Errors = append(checklist.Errors, checklist.DCConnectivity.Errors...)
+	}
+
+	// Check 3: Time synchronization (warning only - actual sync is done by PowerShell)
+	// Note: We can't accurately check time skew from Go without NTP parsing
+	// The PowerShell script handles the actual time sync
+	if !checklist.DCConnectivity.NTPReachable {
+		checklist.Warnings = append(checklist.Warnings,
+			"NTP service not reachable - ensure time is synchronized before domain join")
+	}
+	// Assume time is in sync for the checklist - actual verification is done by PowerShell
+	checklist.TimeInSync = true
+
+	// Determine if ready for join
+	checklist.ReadyForJoin = tunnelUp &&
+		checklist.DCConnectivity.AllRequired &&
+		len(checklist.Errors) == 0
+
+	if checklist.ReadyForJoin {
+		log.Info("Pre-join checklist passed - ready for domain join")
+	} else {
+		log.Errorf("Pre-join checklist failed: %v", checklist.Errors)
+	}
+
+	return checklist
+}
+
+// DomainJoinConfig contains configuration for domain join.
+type DomainJoinConfig struct {
+	// DomainName is the FQDN of the domain (e.g., "corp.local").
+	DomainName string
+
+	// DCAddress is the IP address of the Domain Controller.
+	DCAddress string
+
+	// OUPath is the optional OU path for the computer object.
+	// Format: "OU=Computers,DC=corp,DC=local"
+	OUPath string
+
+	// RestartAfterJoin indicates if the system should restart after join.
+	RestartAfterJoin bool
+
+	// UseCredentials indicates if credentials should be prompted.
+	// If false, uses the current user's credentials.
+	UseCredentials bool
+}
+
+// GenerateDomainJoinScript generates a PowerShell script for domain join.
+// This is meant to be executed by the Windows service or an elevated process.
+func GenerateDomainJoinScript(config *DomainJoinConfig) string {
+	restartFlag := "$false"
+	if config.RestartAfterJoin {
+		restartFlag = "$true"
+	}
+
+	credentialPart := ""
+	if config.UseCredentials {
+		credentialPart = " -Credential (Get-Credential -Message 'Domain Admin credentials')"
+	}
+
+	ouPart := ""
+	if config.OUPath != "" {
+		ouPart = fmt.Sprintf(" -OUPath '%s'", config.OUPath)
+	}
+
+	script := fmt.Sprintf(`# Domain Join Script (Generated by NetBird Machine Tunnel)
+# Prerequisites: Tunnel up, DC reachable, time synchronized
+
+$ErrorActionPreference = 'Stop'
+$dcIP = '%s'
+$domain = '%s'
+
+# Step 1: Verify DC connectivity
+Write-Host "Verifying DC connectivity..."
+
+if (-not (Test-NetConnection -ComputerName $dcIP -Port 389 -WarningAction SilentlyContinue).TcpTestSucceeded) {
+    throw "LDAP (port 389) not reachable - check tunnel status"
+}
+
+if (-not (Test-NetConnection -ComputerName $dcIP -Port 88 -WarningAction SilentlyContinue).TcpTestSucceeded) {
+    throw "Kerberos (port 88) not reachable - check tunnel status"
+}
+
+Write-Host "DC connectivity verified."
+
+# Step 2: Configure NTP via DC (before domain join)
+Write-Host "Configuring NTP sync..."
+try {
+    w32tm /config /manualpeerlist:"$dcIP" /syncfromflags:manual /reliable:no /update
+    Restart-Service W32Time -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 2
+    w32tm /resync /nowait
+    Write-Host "NTP configured successfully."
+} catch {
+    Write-Warning "NTP configuration failed: $_"
+}
+
+# Step 3: Domain Join
+Write-Host "Joining domain: $domain"
+try {
+    Add-Computer -DomainName $domain%s%s -Restart:%s -Force
+    Write-Host "Domain join successful!"
+} catch {
+    throw "Domain join failed: $_"
+}
+`, config.DCAddress, config.DomainName, ouPart, credentialPart, restartFlag)
+
+	return script
+}

--- a/client/internal/tunnel/domainjoin_test.go
+++ b/client/internal/tunnel/domainjoin_test.go
@@ -1,0 +1,267 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultPorts(t *testing.T) {
+	assert.Equal(t, 389, PortLDAP)
+	assert.Equal(t, 636, PortLDAPS)
+	assert.Equal(t, 88, PortKerberos)
+	assert.Equal(t, 53, PortDNS)
+	assert.Equal(t, 445, PortSMB)
+	assert.Equal(t, 123, PortNTP)
+	assert.Equal(t, 135, PortRPCEPM)
+}
+
+func TestCheckTCPPort_Reachable(t *testing.T) {
+	// Start a local TCP listener
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	// Extract the port
+	addr := listener.Addr().(*net.TCPAddr)
+
+	ctx := context.Background()
+	result := checkTCPPort(ctx, "127.0.0.1", addr.Port, time.Second)
+	assert.True(t, result)
+}
+
+func TestCheckTCPPort_Unreachable(t *testing.T) {
+	ctx := context.Background()
+	// Use a port that's unlikely to be open
+	result := checkTCPPort(ctx, "127.0.0.1", 59999, 100*time.Millisecond)
+	assert.False(t, result)
+}
+
+func TestCheckTCPPort_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	result := checkTCPPort(ctx, "127.0.0.1", 80, time.Second)
+	assert.False(t, result)
+}
+
+func TestCheckDCConnectivity_AllUnreachable(t *testing.T) {
+	ctx := context.Background()
+	// Use an IP that doesn't exist (TEST-NET-1)
+	result := CheckDCConnectivity(ctx, "192.0.2.1", 100*time.Millisecond)
+
+	assert.Equal(t, "192.0.2.1", result.DCAddress)
+	assert.False(t, result.LDAPReachable)
+	assert.False(t, result.KerberosReachable)
+	assert.False(t, result.DNSReachable)
+	assert.False(t, result.AllRequired)
+	assert.NotEmpty(t, result.Errors)
+}
+
+func TestCheckDCConnectivity_DefaultTimeout(t *testing.T) {
+	ctx := context.Background()
+	// This tests that zero timeout uses default
+	result := CheckDCConnectivity(ctx, "192.0.2.1", 0)
+	// Just verify it doesn't panic and returns a result
+	assert.NotNil(t, result)
+}
+
+func TestValidatePreJoinRequirements_TunnelDown(t *testing.T) {
+	ctx := context.Background()
+	checklist := ValidatePreJoinRequirements(ctx, "192.168.100.20", false)
+
+	assert.False(t, checklist.TunnelUp)
+	assert.False(t, checklist.ReadyForJoin)
+	assert.Contains(t, checklist.Errors, "VPN tunnel is not established")
+}
+
+func TestValidatePreJoinRequirements_TunnelUpDCUnreachable(t *testing.T) {
+	ctx := context.Background()
+	// Use TEST-NET-1 which is unreachable
+	checklist := ValidatePreJoinRequirements(ctx, "192.0.2.1", true)
+
+	assert.True(t, checklist.TunnelUp)
+	assert.False(t, checklist.ReadyForJoin)
+	assert.NotEmpty(t, checklist.Errors)
+}
+
+func TestPreJoinChecklist_Fields(t *testing.T) {
+	checklist := &PreJoinChecklist{
+		TunnelUp:   true,
+		TimeInSync: true,
+		Errors:     []string{},
+		Warnings:   []string{"test warning"},
+	}
+
+	assert.True(t, checklist.TunnelUp)
+	assert.True(t, checklist.TimeInSync)
+	assert.Empty(t, checklist.Errors)
+	assert.Len(t, checklist.Warnings, 1)
+}
+
+func TestDCConnectivityResult_Fields(t *testing.T) {
+	result := &DCConnectivityResult{
+		DCAddress:         "192.168.100.20",
+		LDAPReachable:     true,
+		KerberosReachable: true,
+		DNSReachable:      true,
+		SMBReachable:      false,
+		AllRequired:       true,
+		Errors:            []string{},
+	}
+
+	assert.Equal(t, "192.168.100.20", result.DCAddress)
+	assert.True(t, result.LDAPReachable)
+	assert.True(t, result.KerberosReachable)
+	assert.True(t, result.DNSReachable)
+	assert.False(t, result.SMBReachable)
+	assert.True(t, result.AllRequired)
+}
+
+func TestGenerateDomainJoinScript_Basic(t *testing.T) {
+	config := &DomainJoinConfig{
+		DomainName:       "corp.local",
+		DCAddress:        "192.168.100.20",
+		RestartAfterJoin: false,
+		UseCredentials:   false,
+	}
+
+	script := GenerateDomainJoinScript(config)
+
+	assert.Contains(t, script, "192.168.100.20")
+	assert.Contains(t, script, "corp.local")
+	assert.Contains(t, script, "Add-Computer")
+	assert.Contains(t, script, "Test-NetConnection")
+	assert.Contains(t, script, "w32tm")
+	assert.Contains(t, script, "-Restart:$false")
+}
+
+func TestGenerateDomainJoinScript_WithRestart(t *testing.T) {
+	config := &DomainJoinConfig{
+		DomainName:       "corp.local",
+		DCAddress:        "192.168.100.20",
+		RestartAfterJoin: true,
+		UseCredentials:   false,
+	}
+
+	script := GenerateDomainJoinScript(config)
+
+	assert.Contains(t, script, "-Restart:$true")
+}
+
+func TestGenerateDomainJoinScript_WithCredentials(t *testing.T) {
+	config := &DomainJoinConfig{
+		DomainName:       "corp.local",
+		DCAddress:        "192.168.100.20",
+		RestartAfterJoin: false,
+		UseCredentials:   true,
+	}
+
+	script := GenerateDomainJoinScript(config)
+
+	assert.Contains(t, script, "Get-Credential")
+	assert.Contains(t, script, "-Credential")
+}
+
+func TestGenerateDomainJoinScript_WithOUPath(t *testing.T) {
+	config := &DomainJoinConfig{
+		DomainName:       "corp.local",
+		DCAddress:        "192.168.100.20",
+		OUPath:           "OU=Workstations,DC=corp,DC=local",
+		RestartAfterJoin: false,
+		UseCredentials:   false,
+	}
+
+	script := GenerateDomainJoinScript(config)
+
+	assert.Contains(t, script, "-OUPath")
+	assert.Contains(t, script, "OU=Workstations,DC=corp,DC=local")
+}
+
+func TestGenerateDomainJoinScript_FullConfig(t *testing.T) {
+	config := &DomainJoinConfig{
+		DomainName:       "test.local",
+		DCAddress:        "10.0.0.1",
+		OUPath:           "OU=Computers,DC=test,DC=local",
+		RestartAfterJoin: true,
+		UseCredentials:   true,
+	}
+
+	script := GenerateDomainJoinScript(config)
+
+	// Verify all components are present
+	assert.Contains(t, script, "test.local")
+	assert.Contains(t, script, "10.0.0.1")
+	assert.Contains(t, script, "OU=Computers,DC=test,DC=local")
+	assert.Contains(t, script, "-Restart:$true")
+	assert.Contains(t, script, "-Credential")
+
+	// Verify the script structure
+	assert.Contains(t, script, "# Step 1: Verify DC connectivity")
+	assert.Contains(t, script, "# Step 2: Configure NTP")
+	assert.Contains(t, script, "# Step 3: Domain Join")
+}
+
+func TestMaxKerberosTimeSkew(t *testing.T) {
+	assert.Equal(t, 5*time.Minute, MaxKerberosTimeSkew)
+}
+
+func TestDefaultConnectTimeout(t *testing.T) {
+	assert.Equal(t, 5*time.Second, DefaultConnectTimeout)
+}
+
+// TestLocalServerDCConnectivity simulates a partial DC by starting local listeners
+func TestLocalServerDCConnectivity(t *testing.T) {
+	// Start mock LDAP server
+	ldapListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ldapListener.Close()
+	ldapPort := ldapListener.Addr().(*net.TCPAddr).Port
+
+	// Start mock Kerberos server
+	kerberosListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer kerberosListener.Close()
+	kerberosPort := kerberosListener.Addr().(*net.TCPAddr).Port
+
+	// Start mock DNS server
+	dnsListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer dnsListener.Close()
+	dnsPort := dnsListener.Addr().(*net.TCPAddr).Port
+
+	// Test individual port checks
+	ctx := context.Background()
+	timeout := 100 * time.Millisecond
+
+	assert.True(t, checkTCPPort(ctx, "127.0.0.1", ldapPort, timeout), "LDAP port should be reachable")
+	assert.True(t, checkTCPPort(ctx, "127.0.0.1", kerberosPort, timeout), "Kerberos port should be reachable")
+	assert.True(t, checkTCPPort(ctx, "127.0.0.1", dnsPort, timeout), "DNS port should be reachable")
+
+	// Close ports to verify unreachability detection
+	ldapListener.Close()
+	assert.False(t, checkTCPPort(ctx, "127.0.0.1", ldapPort, timeout), "LDAP port should be unreachable after close")
+}
+
+// Test that the result struct properly captures partial connectivity
+func TestPartialDCConnectivity(t *testing.T) {
+	// Create a result manually to test logic
+	result := &DCConnectivityResult{
+		DCAddress:         "test.dc",
+		LDAPReachable:     true,
+		KerberosReachable: false, // Missing Kerberos
+		DNSReachable:      true,
+		Errors:            []string{fmt.Sprintf("Kerberos (port %d) not reachable", PortKerberos)},
+	}
+
+	// Calculate AllRequired
+	result.AllRequired = result.LDAPReachable && result.KerberosReachable && result.DNSReachable
+
+	assert.False(t, result.AllRequired, "AllRequired should be false when Kerberos is missing")
+	assert.Len(t, result.Errors, 1)
+}

--- a/management/Dockerfile.multistage
+++ b/management/Dockerfile.multistage
@@ -1,0 +1,13 @@
+FROM golang:1.25 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -ldflags="-s -w" -o /netbird-mgmt ./management/
+
+FROM ubuntu:24.04
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /netbird-mgmt /go/bin/netbird-mgmt
+RUN chmod +x /go/bin/netbird-mgmt
+ENTRYPOINT ["/go/bin/netbird-mgmt", "management"]
+CMD ["--log-file", "console"]

--- a/scripts/bootstrap-new-client.ps1
+++ b/scripts/bootstrap-new-client.ps1
@@ -1,0 +1,475 @@
+<#
+.SYNOPSIS
+    Bootstrap script for new NetBird Machine Tunnel clients.
+    Performs Phase 1 (Setup-Key) -> Domain Join -> Certificate Enrollment -> Phase 2 (mTLS).
+
+.DESCRIPTION
+    This script automates the full bootstrap process for a new Windows client:
+    1. Pre-Tunnel NTP sync (pool.ntp.org)
+    2. Install/Start NetBird Machine Service with Setup-Key
+    3. Wait for tunnel establishment
+    4. Verify DC connectivity via tunnel
+    5. NTP sync with DC (Kerberos requirement)
+    6. Domain Join
+    7. Certificate Enrollment via AD CS
+    8. Update NetBird config for mTLS
+    9. Restart service for Phase 2
+
+.PARAMETER SetupKey
+    The one-time Setup-Key from NetBird Management (UUID format).
+
+.PARAMETER DomainName
+    The FQDN of the Active Directory domain (e.g., "corp.local").
+
+.PARAMETER DCAddress
+    The IP address of the Domain Controller (e.g., "192.168.100.20").
+
+.PARAMETER OUPath
+    Optional. The OU path for the computer object.
+    Format: "OU=Computers,DC=corp,DC=local"
+
+.PARAMETER CertTemplateName
+    The AD CS certificate template name for machine certificates.
+    Default: "NetBirdMachineTunnel"
+
+.PARAMETER NoRestart
+    Skip automatic restart after domain join.
+
+.PARAMETER WhatIf
+    Show what would be done without making changes.
+
+.EXAMPLE
+    .\bootstrap-new-client.ps1 -SetupKey "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -DomainName "corp.local" -DCAddress "192.168.100.20"
+
+.NOTES
+    Requires: Administrator privileges, PowerShell 5.1+
+    Author: NetBird Machine Tunnel Fork
+    Version: 1.0.0
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')]
+    [string]$SetupKey,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DomainName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')]
+    [string]$DCAddress,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OUPath = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$CertTemplateName = "NetBirdMachineTunnel",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoRestart
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'Continue'
+
+# Configuration paths
+$NetBirdConfigPath = "$env:ProgramData\NetBird\config.yaml"
+$NetBirdServiceName = "NetBirdMachine"
+$TunnelInterface = "wg-nb-machine"
+
+#region Helper Functions
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n========================================" -ForegroundColor Cyan
+    Write-Host "  $Message" -ForegroundColor Cyan
+    Write-Host "========================================`n" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[OK] $Message" -ForegroundColor Green
+}
+
+function Write-Warning {
+    param([string]$Message)
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+}
+
+function Write-Failure {
+    param([string]$Message)
+    Write-Host "[FAIL] $Message" -ForegroundColor Red
+}
+
+function Test-Administrator {
+    $currentUser = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    return $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-DCConnectivity {
+    param([string]$DC, [int]$Port)
+
+    try {
+        $result = Test-NetConnection -ComputerName $DC -Port $Port -WarningAction SilentlyContinue -ErrorAction Stop
+        return $result.TcpTestSucceeded
+    } catch {
+        return $false
+    }
+}
+
+function Wait-TunnelUp {
+    param(
+        [int]$TimeoutSeconds = 60,
+        [int]$CheckIntervalSeconds = 2
+    )
+
+    $elapsed = 0
+    while ($elapsed -lt $TimeoutSeconds) {
+        # Check if tunnel interface exists
+        $interface = Get-NetAdapter -Name $TunnelInterface -ErrorAction SilentlyContinue
+        if ($interface -and $interface.Status -eq 'Up') {
+            return $true
+        }
+
+        Start-Sleep -Seconds $CheckIntervalSeconds
+        $elapsed += $CheckIntervalSeconds
+        Write-Host "." -NoNewline
+    }
+    Write-Host ""
+    return $false
+}
+
+function Get-TimeDifferenceSeconds {
+    param([string]$NtpServer)
+
+    try {
+        $output = w32tm /stripchart /computer:$NtpServer /samples:1 /dataonly 2>&1
+        if ($output -match '([+-]?\d+\.\d+)s') {
+            return [math]::Abs([double]$Matches[1])
+        }
+    } catch {
+        Write-Warning "Could not measure time difference: $_"
+    }
+    return $null
+}
+
+#endregion
+
+#region Main Script
+
+# Check prerequisites
+if (-not (Test-Administrator)) {
+    throw "This script must be run as Administrator"
+}
+
+Write-Host @"
+
+╔═══════════════════════════════════════════════════════════════════╗
+║          NetBird Machine Tunnel Bootstrap Script                  ║
+║                                                                   ║
+║  Phase 1: Setup-Key → Domain Join → Cert → Phase 2: mTLS         ║
+╚═══════════════════════════════════════════════════════════════════╝
+
+"@ -ForegroundColor Cyan
+
+Write-Host "Configuration:" -ForegroundColor White
+Write-Host "  Domain:    $DomainName"
+Write-Host "  DC:        $DCAddress"
+Write-Host "  Setup-Key: $($SetupKey.Substring(0,8))..."
+if ($OUPath) { Write-Host "  OU Path:   $OUPath" }
+Write-Host ""
+
+# ============================================
+# Step 1: Pre-Tunnel NTP Sync
+# ============================================
+Write-Step "Step 1: Pre-Tunnel NTP Sync (Public NTP)"
+
+if ($PSCmdlet.ShouldProcess("W32Time", "Configure public NTP")) {
+    try {
+        # Use public NTP before tunnel is up
+        w32tm /config /manualpeerlist:"pool.ntp.org" /syncfromflags:manual /reliable:no /update | Out-Null
+        Restart-Service W32Time -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+        w32tm /resync /nowait | Out-Null
+        Write-Success "Public NTP sync initiated"
+    } catch {
+        Write-Warning "Public NTP sync failed: $_ (continuing...)"
+    }
+}
+
+# ============================================
+# Step 2: Start NetBird Service with Setup-Key
+# ============================================
+Write-Step "Step 2: Starting NetBird Machine Service (Phase 1: Setup-Key)"
+
+if ($PSCmdlet.ShouldProcess($NetBirdServiceName, "Install and start with Setup-Key")) {
+    # Check if service exists
+    $service = Get-Service -Name $NetBirdServiceName -ErrorAction SilentlyContinue
+
+    if (-not $service) {
+        throw "NetBird Machine Service is not installed. Run the installer first."
+    }
+
+    # Update config with setup key
+    if (Test-Path $NetBirdConfigPath) {
+        $config = Get-Content $NetBirdConfigPath -Raw
+        if ($config -notmatch 'setup_key:') {
+            Add-Content $NetBirdConfigPath "`nsetup_key: $SetupKey"
+        } else {
+            $config = $config -replace 'setup_key:.*', "setup_key: $SetupKey"
+            Set-Content $NetBirdConfigPath $config
+        }
+        Write-Success "Config updated with Setup-Key"
+    } else {
+        throw "NetBird config not found at $NetBirdConfigPath"
+    }
+
+    # Start/Restart service
+    if ($service.Status -eq 'Running') {
+        Restart-Service $NetBirdServiceName
+    } else {
+        Start-Service $NetBirdServiceName
+    }
+
+    Write-Success "Service started"
+
+    # Wait for tunnel
+    Write-Host "Waiting for tunnel to establish" -NoNewline
+    if (-not (Wait-TunnelUp -TimeoutSeconds 60)) {
+        throw "Tunnel did not come up within 60 seconds. Check NetBird logs."
+    }
+    Write-Success "Tunnel is UP"
+}
+
+# ============================================
+# Step 3: Verify DC Connectivity via Tunnel
+# ============================================
+Write-Step "Step 3: Verifying DC Connectivity via Tunnel"
+
+$requiredPorts = @(
+    @{Name = "LDAP"; Port = 389},
+    @{Name = "Kerberos"; Port = 88},
+    @{Name = "DNS"; Port = 53}
+)
+
+$allReachable = $true
+foreach ($port in $requiredPorts) {
+    Write-Host "  Testing $($port.Name) (port $($port.Port))... " -NoNewline
+    if (Test-DCConnectivity -DC $DCAddress -Port $port.Port) {
+        Write-Success "OK"
+    } else {
+        Write-Failure "FAILED"
+        $allReachable = $false
+    }
+}
+
+if (-not $allReachable) {
+    throw "DC connectivity check failed. Ensure the tunnel routes DC traffic correctly."
+}
+Write-Success "All required DC ports reachable via tunnel"
+
+# ============================================
+# Step 4: NTP Sync with DC (Kerberos Requirement)
+# ============================================
+Write-Step "Step 4: NTP Sync with Domain Controller"
+
+if ($PSCmdlet.ShouldProcess("W32Time", "Configure DC NTP")) {
+    # Configure DC as NTP source
+    w32tm /config /manualpeerlist:"$DCAddress" /syncfromflags:manual /reliable:no /update | Out-Null
+    Restart-Service W32Time -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
+    w32tm /resync /nowait | Out-Null
+
+    # Check time difference
+    $timeDiff = Get-TimeDifferenceSeconds -NtpServer $DCAddress
+    if ($null -ne $timeDiff) {
+        if ($timeDiff -gt 300) {
+            Write-Warning "Time difference is ${timeDiff}s (>5min). Kerberos may fail!"
+            Write-Host "  Waiting for sync..." -NoNewline
+            Start-Sleep -Seconds 10
+            w32tm /resync /nowait | Out-Null
+            Start-Sleep -Seconds 5
+            $timeDiff = Get-TimeDifferenceSeconds -NtpServer $DCAddress
+        }
+
+        if ($null -ne $timeDiff -and $timeDiff -le 300) {
+            Write-Success "Time synchronized (diff: ${timeDiff}s)"
+        } else {
+            Write-Warning "Could not verify time sync. Proceeding with caution."
+        }
+    } else {
+        Write-Warning "Could not measure time difference. Proceeding..."
+    }
+}
+
+# ============================================
+# Step 5: Domain Join
+# ============================================
+Write-Step "Step 5: Domain Join"
+
+# Check if already joined
+$computerSystem = Get-WmiObject Win32_ComputerSystem
+if ($computerSystem.PartOfDomain -and $computerSystem.Domain -eq $DomainName) {
+    Write-Success "Computer is already joined to $DomainName"
+} else {
+    if ($PSCmdlet.ShouldProcess($DomainName, "Join domain")) {
+        Write-Host "Joining domain: $DomainName"
+        Write-Host "(You will be prompted for domain admin credentials)"
+
+        $joinParams = @{
+            DomainName = $DomainName
+            Credential = (Get-Credential -Message "Enter domain admin credentials for $DomainName")
+            Force = $true
+            Restart = $false
+        }
+
+        if ($OUPath) {
+            $joinParams.OUPath = $OUPath
+        }
+
+        try {
+            Add-Computer @joinParams
+            Write-Success "Domain join successful!"
+        } catch {
+            throw "Domain join failed: $_"
+        }
+    }
+}
+
+# ============================================
+# Step 6: Certificate Enrollment
+# ============================================
+Write-Step "Step 6: Machine Certificate Enrollment"
+
+if ($PSCmdlet.ShouldProcess("AD CS", "Request machine certificate")) {
+    Write-Host "Requesting machine certificate using template: $CertTemplateName"
+
+    # Use certreq for enrollment
+    $infContent = @"
+[NewRequest]
+Subject = "CN=$env:COMPUTERNAME.$DomainName"
+KeySpec = 1
+KeyLength = 2048
+Exportable = TRUE
+MachineKeySet = TRUE
+SMIME = FALSE
+PrivateKeyArchive = FALSE
+UserProtected = FALSE
+UseExistingKeySet = FALSE
+ProviderName = "Microsoft RSA SChannel Cryptographic Provider"
+ProviderType = 12
+RequestType = PKCS10
+KeyUsage = 0xa0
+
+[RequestAttributes]
+CertificateTemplate = $CertTemplateName
+"@
+
+    $infPath = "$env:TEMP\certreq.inf"
+    $reqPath = "$env:TEMP\certreq.req"
+    $cerPath = "$env:TEMP\certreq.cer"
+
+    try {
+        Set-Content -Path $infPath -Value $infContent
+
+        # Generate request
+        $result = certreq -new -machine $infPath $reqPath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "certreq -new failed: $result"
+        }
+
+        # Submit to CA (assumes auto-enrollment CA discovery)
+        $result = certreq -submit -machine $reqPath $cerPath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "certreq -submit failed: $result"
+        }
+
+        # Accept certificate
+        $result = certreq -accept -machine $cerPath 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "certreq -accept failed: $result"
+        }
+
+        Write-Success "Certificate enrolled successfully"
+
+        # Get thumbprint
+        $cert = Get-ChildItem Cert:\LocalMachine\My |
+            Where-Object { $_.Subject -match $env:COMPUTERNAME } |
+            Sort-Object NotAfter -Descending |
+            Select-Object -First 1
+
+        if ($cert) {
+            Write-Host "  Certificate Thumbprint: $($cert.Thumbprint)"
+            Write-Host "  Valid Until: $($cert.NotAfter)"
+
+            # Save thumbprint for config update
+            $certThumbprint = $cert.Thumbprint
+        }
+    } finally {
+        # Cleanup temp files
+        Remove-Item $infPath, $reqPath, $cerPath -ErrorAction SilentlyContinue
+    }
+}
+
+# ============================================
+# Step 7: Update NetBird Config for mTLS
+# ============================================
+Write-Step "Step 7: Updating NetBird Config for mTLS (Phase 2)"
+
+if ($PSCmdlet.ShouldProcess($NetBirdConfigPath, "Enable mTLS")) {
+    if ($certThumbprint) {
+        # Update config to enable machine cert auth
+        $configUpdate = @"
+
+# Machine Certificate Authentication (Phase 2)
+machine_cert_enabled: true
+machine_cert_thumbprint: $certThumbprint
+"@
+        Add-Content $NetBirdConfigPath $configUpdate
+
+        # Remove setup key from config (security)
+        $config = Get-Content $NetBirdConfigPath -Raw
+        $config = $config -replace 'setup_key:.*\n', ''
+        Set-Content $NetBirdConfigPath $config
+
+        Write-Success "Config updated for mTLS authentication"
+    } else {
+        Write-Warning "No certificate thumbprint available. Skipping mTLS config."
+    }
+}
+
+# ============================================
+# Step 8: Restart or Prompt
+# ============================================
+Write-Step "Step 8: Completing Bootstrap"
+
+if ($NoRestart) {
+    Write-Host @"
+
+Bootstrap complete! Manual steps required:
+1. Restart the computer to complete domain join
+2. After restart, the NetBird service will use mTLS (Phase 2)
+
+"@ -ForegroundColor Yellow
+} else {
+    Write-Host @"
+
+Bootstrap complete!
+
+The computer will restart in 30 seconds to complete:
+- Domain join finalization
+- NetBird service restart with mTLS (Phase 2)
+
+Press Ctrl+C to cancel restart.
+
+"@ -ForegroundColor Green
+
+    if ($PSCmdlet.ShouldProcess("Computer", "Restart")) {
+        Start-Sleep -Seconds 30
+        Restart-Computer -Force
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Summary
- **T-5.1**: Implement `Bootstrap()` method for two-phase machine tunnel authentication
- **T-5.2**: Implement domain join over tunnel with DC connectivity checks

### T-5.1: Bootstrap with Setup-Key Fallback
- Phase 1: Setup-Key authentication for initial enrollment (before AD CS cert)
- Phase 2: mTLS authentication with machine certificate (after cert enrollment)
- `hasMachineCert()`: Validates cert existence, expiry, SAN DNSNames, optional thumbprint
- Auto-selection of auth method based on cert availability

### T-5.2: Domain Join Over Tunnel
- `CheckDCConnectivity()`: Validates LDAP (389), Kerberos (88), DNS (53), SMB (445), NTP (123)
- `ValidatePreJoinRequirements()`: Pre-join checklist (tunnel up, DC reachable, time sync)
- `GenerateDomainJoinScript()`: PowerShell script generator for domain join

### PowerShell Bootstrap Script
- `scripts/bootstrap-new-client.ps1`: Full Phase 1 → Domain Join → Cert → Phase 2 workflow
- NTP sync with public NTP (pre-tunnel) and DC (pre-join)
- Certificate enrollment via AD CS (`certreq`)

## Test plan
- [x] `go build ./client/internal/tunnel/...` - compiles successfully
- [x] `go test -v ./client/internal/tunnel/...` - 33 tests pass (15 bootstrap + 18 domainjoin)
- [ ] Integration test with lab server (blocked on Windows client)

## Documentation
- [x] Documentation is **not needed** (internal client implementation)

Closes #47
Closes #48
Relates to: #7 (S-5)

---
Generated with [Claude Code](https://claude.com/claude-code)