### PR TITLE
ci(release): Use standard GitHub runner instead of larger runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           retention-days: 30
 
   release:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     env:
       flags: ""
     steps:


### PR DESCRIPTION
## Summary
- Change `runs-on: ubuntu-latest-m` to `runs-on: ubuntu-latest` in release workflow
- Fixes perpetually pending release job on personal free-plan fork

## Impact
Release job will actually run instead of timing out after 24h.

Closes #122

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>