### PR TITLE
feat(server): Complete S-3 Server mTLS implementation

### DIFF
--- a/management/internals/server/mtls_auth.go
+++ b/management/internals/server/mtls_auth.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/idna"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -318,9 +319,16 @@ func extractMTLSIdentity(ctx context.Context) (*MTLSIdentity, error) {
 	var validationErr error
 
 	for _, dnsName := range clientCert.DNSNames {
-		hostname, domain, err := splitDNSName(dnsName)
+		// Canonicalize SAN: lowercase, IDNA, strip trailing dot, validate RFC 1123
+		canonicalName, err := canonicalizeSAN(dnsName)
 		if err != nil {
 			log.Debugf("Skipping invalid SAN DNSName %q: %v", dnsName, err)
+			continue
+		}
+
+		hostname, domain, err := splitDNSName(canonicalName)
+		if err != nil {
+			log.Debugf("Skipping invalid SAN DNSName %q: %v", canonicalName, err)
 			continue
 		}
 
@@ -341,7 +349,7 @@ func extractMTLSIdentity(ctx context.Context) (*MTLSIdentity, error) {
 		}
 
 		// Found valid SAN!
-		validDNSName = dnsName
+		validDNSName = canonicalName
 		validHostname = hostname
 		validDomain = domain
 		accountID = accID
@@ -403,6 +411,69 @@ func extractMTLSIdentity(ctx context.Context) (*MTLSIdentity, error) {
 	}
 
 	return identity, nil
+}
+
+// canonicalizeSAN normalizes a SAN DNSName for consistent matching:
+// 1. Reject wildcards (not valid for machine identity)
+// 2. Lowercase normalization
+// 3. Strip trailing dot (DNS root marker)
+// 4. IDNA normalization (internationalized domain names)
+// 5. RFC 1123 DNS label validation (1-63 chars, alphanumeric start/end)
+func canonicalizeSAN(dnsName string) (string, error) {
+	if dnsName == "" {
+		return "", fmt.Errorf("empty SAN DNSName")
+	}
+
+	// Reject wildcards — machine certs must not use wildcard SANs
+	if strings.Contains(dnsName, "*") {
+		return "", fmt.Errorf("wildcard SAN not allowed for machine identity: %s", dnsName)
+	}
+
+	// Lowercase normalization
+	name := strings.ToLower(dnsName)
+
+	// Strip trailing dot (DNS root marker, e.g. "host.domain.local.")
+	name = strings.TrimSuffix(name, ".")
+
+	// IDNA normalization (handles internationalized domain names)
+	normalized, err := idna.Lookup.ToASCII(name)
+	if err != nil {
+		return "", fmt.Errorf("IDNA normalization failed for %q: %w", dnsName, err)
+	}
+	name = normalized
+
+	// RFC 1123 DNS label validation
+	labels := strings.Split(name, ".")
+	if len(labels) < 2 {
+		return "", fmt.Errorf("SAN must be FQDN (at least hostname.domain): %s", dnsName)
+	}
+
+	for _, label := range labels {
+		if len(label) == 0 || len(label) > 63 {
+			return "", fmt.Errorf("DNS label length invalid (must be 1-63): %q in %s", label, dnsName)
+		}
+		// Must start with alphanumeric
+		if !isAlphanumeric(label[0]) {
+			return "", fmt.Errorf("DNS label must start with alphanumeric: %q in %s", label, dnsName)
+		}
+		// Must end with alphanumeric
+		if !isAlphanumeric(label[len(label)-1]) {
+			return "", fmt.Errorf("DNS label must end with alphanumeric: %q in %s", label, dnsName)
+		}
+		// Interior characters: alphanumeric or hyphen
+		for i := 1; i < len(label)-1; i++ {
+			if !isAlphanumeric(label[i]) && label[i] != '-' {
+				return "", fmt.Errorf("DNS label contains invalid character %q: %q in %s", label[i], label, dnsName)
+			}
+		}
+	}
+
+	return name, nil
+}
+
+// isAlphanumeric returns true if b is a-z, A-Z, or 0-9.
+func isAlphanumeric(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 // splitDNSName splits a FQDN into hostname and domain parts.

--- a/management/internals/server/mtls_auth_test.go
+++ b/management/internals/server/mtls_auth_test.go
@@ -147,6 +147,75 @@ func TestExtractMTLSIdentityNoSAN(t *testing.T) {
 	t.Logf("✅ Correctly rejected cert without SAN: %v", err)
 }
 
+// TestCanonicalizeSAN tests SAN DNS name canonicalization.
+func TestCanonicalizeSAN(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		// Valid cases
+		{"standard FQDN", "win10-pc.corp.local", "win10-pc.corp.local", false},
+		{"uppercase normalization", "WIN10-PC.CORP.LOCAL", "win10-pc.corp.local", false},
+		{"mixed case", "Desktop-2G62OLC.test.local", "desktop-2g62olc.test.local", false},
+		{"trailing dot stripped", "host.domain.local.", "host.domain.local", false},
+		{"uppercase with trailing dot", "HOST.DOMAIN.LOCAL.", "host.domain.local", false},
+		{"multi-level domain", "srv01.sub.corp.example.com", "srv01.sub.corp.example.com", false},
+		{"numeric hostname", "pc123.domain.local", "pc123.domain.local", false},
+		{"hyphenated labels", "my-host.my-domain.local", "my-host.my-domain.local", false},
+		// Error cases
+		{"empty string", "", "", true},
+		{"wildcard rejected", "*.corp.local", "", true},
+		{"wildcard in hostname", "host*.corp.local", "", true},
+		{"single label not FQDN", "hostname", "", true},
+		{"label too long (64 chars)", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn.domain.local", "", true},
+		{"label starts with hyphen", "-host.domain.local", "", true},
+		{"label ends with hyphen", "host-.domain.local", "", true},
+		{"empty label (double dot)", "host..domain.local", "", true},
+		{"underscore in label", "my_host.domain.local", "", true},
+		{"space in label", "my host.domain.local", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := canonicalizeSAN(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("canonicalizeSAN(%q) = %q, expected error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("canonicalizeSAN(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("canonicalizeSAN(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAlphanumeric tests the helper function.
+func TestIsAlphanumeric(t *testing.T) {
+	for _, b := range []byte("abcdefghijklmnopqrstuvwxyz0123456789") {
+		if !isAlphanumeric(b) {
+			t.Errorf("isAlphanumeric(%q) = false, want true", b)
+		}
+	}
+	for _, b := range []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		if !isAlphanumeric(b) {
+			t.Errorf("isAlphanumeric(%q) = false, want true", b)
+		}
+	}
+	for _, b := range []byte("-_.! @") {
+		if isAlphanumeric(b) {
+			t.Errorf("isAlphanumeric(%q) = true, want false", b)
+		}
+	}
+}
+
 // TestSplitDNSName tests the FQDN splitting function.
 func TestSplitDNSName(t *testing.T) {
 	tests := []struct {

--- a/management/internals/server/server.go
+++ b/management/internals/server/server.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	nbgrpc "github.com/netbirdio/netbird/management/internals/shared/grpc"
 	"github.com/netbirdio/netbird/management/server/idp"
+	mgmtProto "github.com/netbirdio/netbird/shared/management/proto"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/crypto/acme/autocert"
@@ -398,6 +400,17 @@ func (s *BaseServer) startMTLSServer(ctx context.Context) error {
 		return fmt.Errorf("failed to create mTLS server: %w", err)
 	}
 
+	// Initialize mTLS domain-account mapping (CRITICAL for multi-tenant isolation)
+	if len(s.Config.HttpConfig.MTLSDomainAccountMapping) > 0 {
+		SetMTLSConfig(&MTLSConfig{
+			DomainAccountMapping:  s.Config.HttpConfig.MTLSDomainAccountMapping,
+			AccountAllowedDomains: s.Config.HttpConfig.MTLSAccountAllowedDomains,
+			AccountAllowedIssuers: s.Config.HttpConfig.MTLSAccountAllowedIssuers,
+		})
+	} else {
+		log.WithContext(ctx).Warn("mTLS server: no MTLSDomainAccountMapping configured - domain validation will use fallback mode")
+	}
+
 	// Initialize mTLS validator config with account-issuer mappings
 	if len(s.Config.HttpConfig.MTLSAccountAllowedIssuers) > 0 {
 		InitMTLSValidatorConfig(s.Config.HttpConfig.MTLSAccountAllowedIssuers)
@@ -406,10 +419,13 @@ func (s *BaseServer) startMTLSServer(ctx context.Context) error {
 	// Create gRPC server with mTLS credentials
 	grpcServer := s.mtlsServer.CreateGRPCServer()
 
-	// Register Machine-only services on mTLS port
-	// Note: These services will be registered by the caller after this method returns
-	// The grpcServer is available via s.mtlsServer.GetServer()
-	_ = grpcServer // Services registered externally
+	// Register ManagementService on mTLS port (RegisterMachinePeer, SyncMachinePeer etc.)
+	srv, err := nbgrpc.NewServer(s.Config, s.AccountManager(), s.SettingsManager(), s.SecretsManager(), s.Metrics(), s.AuthManager(), s.IntegratedValidator(), s.NetworkMapController(), s.OAuthConfigProvider())
+	if err != nil {
+		return fmt.Errorf("failed to create management server for mTLS port: %w", err)
+	}
+	mgmtProto.RegisterManagementServiceServer(grpcServer, srv)
+	log.WithContext(ctx).Info("ManagementService registered on mTLS port")
 
 	// Start the mTLS server
 	if err := s.mtlsServer.Start(ctx); err != nil {

--- a/management/internals/server/server.go
+++ b/management/internals/server/server.go
@@ -393,9 +393,12 @@ func (s *BaseServer) startMTLSServer(ctx context.Context) error {
 		port = MTLSServerPort
 	}
 
-	// Create mTLS server
+	// Create mTLS server with identity extraction interceptor
 	var err error
-	s.mtlsServer, err = NewMTLSServer(certFile, keyFile, caDir, caCertFile, port, nil)
+	mtlsInterceptors := []grpc.UnaryServerInterceptor{
+		MTLSUnaryInterceptor(true), // strictMode=true: all methods on mTLS port require client cert
+	}
+	s.mtlsServer, err = NewMTLSServer(certFile, keyFile, caDir, caCertFile, port, mtlsInterceptors)
 	if err != nil {
 		return fmt.Errorf("failed to create mTLS server: %w", err)
 	}

--- a/management/internals/shared/grpc/machine_tunnel.go
+++ b/management/internals/shared/grpc/machine_tunnel.go
@@ -101,13 +101,6 @@ func (s *Server) RegisterMachinePeer(ctx context.Context, req *proto.MachineRegi
 		UserID:   "",
 	})
 	if err != nil {
-		// Check if this is a "no auth method" error and provide better message
-		if err.Error() == "no peer auth method provided, please use a setup key or interactive SSO login" {
-			log.WithContext(ctx).Errorf("LoginPeer rejected mTLS auth - mTLS context not recognized. "+
-				"This may indicate AddPeer needs mTLS support. Error: %v", err)
-			return nil, status.Errorf(codes.Internal,
-				"machine peer registration not fully implemented - AddPeer needs mTLS support")
-		}
 		log.WithContext(ctx).Errorf("Failed to register machine peer: %v", err)
 		return nil, status.Errorf(codes.Internal, "failed to register peer: %v", err)
 	}

--- a/management/internals/shared/grpc/machine_tunnel.go
+++ b/management/internals/shared/grpc/machine_tunnel.go
@@ -60,12 +60,22 @@ func (s *Server) RegisterMachinePeer(ctx context.Context, req *proto.MachineRegi
 	}
 
 	// Parse WireGuard public key from request
-	if len(req.GetWgPubKey()) == 0 {
+	// wg_pub_key is a bytes field containing the raw 32-byte key OR a base64-encoded string
+	wgPubKeyBytes := req.GetWgPubKey()
+	if len(wgPubKeyBytes) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "WireGuard public key is required")
 	}
-	peerKey, err := wgtypes.ParseKey(string(req.GetWgPubKey()))
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid WireGuard public key: %v", err)
+	var peerKey wgtypes.Key
+	var wgErr error
+	if len(wgPubKeyBytes) == wgtypes.KeyLen {
+		// Raw 32-byte key (from protobuf bytes field)
+		peerKey, wgErr = wgtypes.NewKey(wgPubKeyBytes)
+	} else {
+		// Base64-encoded string (fallback for compatibility)
+		peerKey, wgErr = wgtypes.ParseKey(string(wgPubKeyBytes))
+	}
+	if wgErr != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid WireGuard public key: %v", wgErr)
 	}
 
 	// Add peer and account info to context for logging

--- a/management/server/activity/codes.go
+++ b/management/server/activity/codes.go
@@ -195,6 +195,9 @@ const (
 	DNSRecordUpdated Activity = 100
 	DNSRecordDeleted Activity = 101
 
+	// Machine Tunnel Fork: mTLS peer registration activity
+	PeerAddedWithMTLS Activity = 102
+
 	AccountDeleted Activity = 99999
 )
 
@@ -319,6 +322,9 @@ var activityMap = map[Activity]Code{
 	DNSRecordCreated: {"DNS zone record created", "dns.zone.record.create"},
 	DNSRecordUpdated: {"DNS zone record updated", "dns.zone.record.update"},
 	DNSRecordDeleted: {"DNS zone record deleted", "dns.zone.record.delete"},
+
+	// Machine Tunnel Fork
+	PeerAddedWithMTLS: {"Machine peer added via mTLS", "peer.mtls.add"},
 }
 
 // StringCode returns a string code of the activity

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -632,6 +632,10 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 				if err != nil {
 					log.WithContext(ctx).Debugf("failed to update user last login: %v", err)
 				}
+			} else if addedByMTLS {
+				// Machine Tunnel Fork: mTLS peers don't use setup keys
+				// No setup key usage to increment, no user login to save
+				log.WithContext(ctx).Debugf("mTLS peer added without setup key: %s", newPeer.DNSLabel)
 			} else {
 				sk, err := transaction.GetSetupKeyBySecret(ctx, store.LockingStrengthUpdate, encodedHashedKey)
 				if err != nil {

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -418,7 +418,11 @@ func (am *DefaultAccountManager) GetPeerNetwork(ctx context.Context, peerID stri
 // Each new Peer will be assigned a new next net.IP from the Account.Network and Account.Network.LastIP will be updated (IP's are not reused).
 // The peer property is just a placeholder for the Peer properties to pass further
 func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKey, userID string, peer *nbpeer.Peer, temporary bool) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error) {
-	if setupKey == "" && userID == "" {
+	// Machine Tunnel Fork: mTLS as third auth method (alongside setup key and user/SSO)
+	mTLSIdentity := mtls.GetIdentity(ctx)
+	addedByMTLS := mTLSIdentity != nil && setupKey == "" && userID == ""
+
+	if setupKey == "" && userID == "" && !addedByMTLS {
 		// no auth method provided => reject access
 		return nil, nil, nil, status.Errorf(status.Unauthenticated, "no peer auth method provided, please use a setup key or interactive SSO login")
 	}
@@ -449,7 +453,16 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 	var ephemeral bool
 	var groupsToAdd []string
 	var allowExtraDNSLabels bool
-	if addedByUser {
+	if addedByMTLS {
+		// Machine Tunnel Fork: mTLS-authenticated machine peer
+		accountID = mTLSIdentity.AccountID
+		opEvent.InitiatorID = mTLSIdentity.DNSName
+		opEvent.Activity = activity.PeerAddedWithMTLS
+		groupsToAdd = nil
+		ephemeral = false
+		log.WithContext(ctx).Infof("Adding machine peer via mTLS: DNS=%s, Account=%s",
+			mTLSIdentity.DNSName, mTLSIdentity.AccountID)
+	} else if addedByUser {
 		user, err := am.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
 		if err != nil {
 			return nil, nil, nil, status.Errorf(status.NotFound, "failed adding new peer: user not found")

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -453,7 +453,8 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 	var ephemeral bool
 	var groupsToAdd []string
 	var allowExtraDNSLabels bool
-	if addedByMTLS {
+	switch {
+	case addedByMTLS:
 		// Machine Tunnel Fork: mTLS-authenticated machine peer
 		accountID = mTLSIdentity.AccountID
 		opEvent.InitiatorID = mTLSIdentity.DNSName
@@ -462,7 +463,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 		ephemeral = false
 		log.WithContext(ctx).Infof("Adding machine peer via mTLS: DNS=%s, Account=%s",
 			mTLSIdentity.DNSName, mTLSIdentity.AccountID)
-	} else if addedByUser {
+	case addedByUser:
 		user, err := am.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
 		if err != nil {
 			return nil, nil, nil, status.Errorf(status.NotFound, "failed adding new peer: user not found")
@@ -485,7 +486,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 		}
 		opEvent.InitiatorID = userID
 		opEvent.Activity = activity.PeerAddedByUser
-	} else {
+	default:
 		// Validate the setup key
 		sk, err := am.Store.GetSetupKeyBySecret(ctx, store.LockingStrengthNone, encodedHashedKey)
 		if err != nil {
@@ -627,16 +628,17 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, accountID, setupKe
 				return fmt.Errorf("failed adding peer to All group: %w", err)
 			}
 
-			if addedByUser {
+			switch {
+			case addedByUser:
 				err := transaction.SaveUserLastLogin(ctx, accountID, userID, newPeer.GetLastLogin())
 				if err != nil {
 					log.WithContext(ctx).Debugf("failed to update user last login: %v", err)
 				}
-			} else if addedByMTLS {
+			case addedByMTLS:
 				// Machine Tunnel Fork: mTLS peers don't use setup keys
 				// No setup key usage to increment, no user login to save
 				log.WithContext(ctx).Debugf("mTLS peer added without setup key: %s", newPeer.DNSLabel)
-			} else {
+			default:
 				sk, err := transaction.GetSetupKeyBySecret(ctx, store.LockingStrengthUpdate, encodedHashedKey)
 				if err != nil {
 					return fmt.Errorf("failed to get setup key: %w", err)


### PR DESCRIPTION
## Describe your changes
Complete S-3 Server mTLS implementation with lab-verified end-to-end authentication chain.

- **canonicalizeSAN**: RFC 1123 DNS name validation with IDNA normalization, trailing dot stripping, wildcard rejection (T-3.3 #29)
- **AddPeer mTLS auth path**: Third authentication method alongside setup keys and SSO, with activity code `PeerAddedWithMTLS` (T-3.6 #32)
- **SetMTLSConfig wiring**: Domain-account mapping initialized at server startup, ManagementService registered on mTLS port (T-3.9 #93)
- **MTLSUnaryInterceptor**: Correctly wired on mTLS gRPC port with `strictMode=true`
- **WG key parsing**: Handle both raw bytes (protobuf) and base64 string input
- **AddPeer transaction fix**: Skip setup key lookup for mTLS peers

### Lab Verification (10.0.0.103:33074)
Full mTLS auth chain verified end-to-end:
```
Cert (TEST-CA) -> TLS 1.3 Handshake -> MTLSUnaryInterceptor -> extractMTLSIdentity
-> canonicalizeSAN -> Domain Mapping -> Account Lookup -> AddPeer -> Peer Created
```

## Issue ticket number and link
Closes #29, Closes #93
Relates to #32, #5

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

Server-internal mTLS wiring - no user-facing changes. Documentation will follow with client-side implementation (S-4).

### Docs PR URL (required if "docs added" is checked)
Paste the PR link from https://github.com/netbirdio/docs here:

## Test plan
- [x] 34 unit tests pass (20 new canonicalizeSAN + 14 existing mTLS tests)
- [x] `go vet` clean on all modified packages
- [x] Lab deployment on netbird-mgmt (Docker, port 33074)
- [x] mTLS TLS handshake verified with AD CS signed client cert
- [x] RegisterMachinePeer RPC returns valid PeerConfig + MachineIdentity

Generated with [Claude Code](https://claude.com/claude-code)