### PR TITLE
fix(ci): add retry and cleanup for Windows checkout failures

### DIFF
--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -17,8 +17,30 @@ jobs:
     name: "Client / Unit"
     runs-on: windows-latest
     steps:
+      - name: Enable long paths
+        run: git config --system core.longpaths true
+
+      - name: Clean workspace
+        run: |
+          if (Test-Path "${{ github.workspace }}\.git") {
+            Write-Host "Removing stale .git directory..."
+            Remove-Item -Recurse -Force "${{ github.workspace }}\.git" -ErrorAction SilentlyContinue
+          }
+
       - name: Checkout code
+        id: checkout
         uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          clean: true
+          persist-credentials: false
+
+      - name: Retry checkout on failure
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          persist-credentials: false
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor-patches/wireguard-go"]
+	path = vendor-patches/wireguard-go
+	url = https://github.com/netbirdio/wireguard-go.git


### PR DESCRIPTION
## Summary
- Windows CI runner frequently fails with `git exit code 128` during `actions/checkout` due to stale `.git` locks, long path issues, and Windows Defender file locking
- Adds `core.longpaths true` before checkout
- Cleans stale `.git` directory from previous runs
- First checkout attempt with `continue-on-error`, automatic retry on failure
- Fixes empty `.gitmodules` that caused `no submodule mapping found` error

## Test plan
- [x] Push triggers CI - verify the Windows "Client / Unit" job passes
- [ ] If checkout succeeds on first try, retry step is skipped (visible in logs)
- [ ] No regression in test output capture (PsExec batching still works)

## Docs
- [x] Documentation is **not needed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)