### PR TITLE
ci: upgrade deprecated Docker actions to v3

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -353,7 +353,7 @@ jobs:
 
       - name: Login to Docker hub
         if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -441,7 +441,7 @@ jobs:
 
       - name: Login to Docker hub
         if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -530,7 +530,7 @@ jobs:
 
       - name: Login to Docker hub
         if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,12 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
## Describe your changes
Upgrade deprecated Docker GitHub Actions that internally use the old `::set-output` command (deprecated by GitHub, will be disabled soon):

| Action | Old | New | Occurrences |
|--------|-----|-----|-------------|
| `docker/login-action` | v1 | v3 | 4 (3x golang-test-linux.yml, 1x release.yml) |
| `docker/setup-qemu-action` | v2 | v3 | 1 (release.yml) |
| `docker/setup-buildx-action` | v2 | v3 | 1 (release.yml) |

This eliminates the 6 "set-output command is deprecated" CI warnings.

## Issue ticket number and link
Closes #131

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)

## Documentation
Select exactly one:

- [ ] I added/updated documentation for this change
- [x] Documentation is **not needed** for this change (explain why)

CI workflow version bumps only - no user-facing changes.

> By submitting this pull request, you confirm that you have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).