### PR TITLE
fix(tunnel): add default port to management URL and fix peer status race condition

### DIFF
--- a/client/internal/tunnel/machine.go
+++ b/client/internal/tunnel/machine.go
@@ -333,10 +333,19 @@ func (t *MachineTunnel) connectionLoop() {
 //   - Setup key is loaded from SecureConfig or MachineTunnelConfig (fallback)
 //   - After first successful bootstrap, keys are persisted to SecureConfig
 func (t *MachineTunnel) toMachineConfig() (*MachineConfig, error) {
-	// Parse management URL
+	// Parse management URL and add default port if missing
+	// (matches standard client behavior in profilemanager/config.go:parseURL)
 	mgmtURL, err := url.Parse(t.config.ManagementURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse management URL: %w", err)
+	}
+	if mgmtURL.Port() == "" {
+		switch mgmtURL.Scheme {
+		case "https":
+			mgmtURL.Host += ":443"
+		case "http":
+			mgmtURL.Host += ":80"
+		}
 	}
 
 	var wgKeyStr string

--- a/client/internal/tunnel/peerengine.go
+++ b/client/internal/tunnel/peerengine.go
@@ -427,6 +427,18 @@ func (pe *PeerEngine) ConnectPeer(ctx context.Context, remotePeerKey string, all
 		return nil, fmt.Errorf("create peer conn: %w", err)
 	}
 
+	// Register peer in statusRecorder BEFORE opening connection.
+	// This prevents "peer doesn't exist" warnings when conn.Open() triggers
+	// state updates via UpdatePeerState/UpdatePeerICEState.
+	// (matches engine.go pattern: createPeerConn → AddPeer → Open)
+	peerIP := ""
+	if len(allowedIPs) > 0 {
+		peerIP = allowedIPs[0]
+	}
+	if err := pe.statusRecorder.AddPeer(remotePeerKey, "", peerIP); err != nil {
+		log.WithField("peer", remotePeerKey[:8]).Debugf("peer already in status recorder: %v", err)
+	}
+
 	if err := conn.Open(ctx); err != nil {
 		return nil, fmt.Errorf("open peer conn: %w", err)
 	}


### PR DESCRIPTION
## Summary
- **Management URL port**: URLs without explicit port (e.g. `https://host`) now default to `:443`/`:80`, matching standard client behavior
- **Peer status race condition**: `statusRecorder.AddPeer()` now called before `conn.Open()`, eliminating "peer doesn't exist" warnings

## Test Evidence (Windows VM 10.0.0.160)

| Test | Before Fix | After Fix |
|------|-----------|-----------|
| `https://10.0.0.103` (no port) | "missing port in address" | Bootstrap successful |
| "peer doesn't exist" warnings | 4+ per connect | 0 |
| DC LDAP/DNS/Kerberos/SMB | N/A (couldn't connect) | All TcpTestSucceeded: True |
| Kerberos TGT (klist) | N/A | 5 cached tickets (AES-256) |
| Key persistence (restart) | N/A | Same peer_ip after restart |
| golangci-lint | N/A | 0 issues |

## Files Changed
- `client/internal/tunnel/machine.go` — default port logic in `toMachineConfig()`
- `client/internal/tunnel/peerengine.go` — `AddPeer()` before `Open()` in `ConnectPeer()`

## Documentation
- [x] Documentation is **not needed**

Closes #113