### PR TITLE
fix(tunnel): fix NRPT/firewall creation, add crash recovery and NTP sync

### DIFF
--- a/client/internal/tunnel/firewall_windows.go
+++ b/client/internal/tunnel/firewall_windows.go
@@ -14,11 +14,10 @@ import (
 )
 
 const (
-	// FirewallRulePrefix is the prefix for Machine Tunnel firewall rules
+	// FirewallRulePrefix is the prefix for Machine Tunnel firewall rules.
+	// Rules are identified by this name prefix for cleanup since netsh
+	// does not support group-based rule management.
 	FirewallRulePrefix = "NetBird-Machine-"
-
-	// FirewallGroupName is the group name for Machine Tunnel firewall rules
-	FirewallGroupName = "NetBird Machine Tunnel"
 )
 
 // FirewallManager handles Windows Firewall rules for DC traffic
@@ -66,7 +65,10 @@ func (m *FirewallManager) addRule(ruleName, direction, remoteIP string) error {
 
 	// Build netsh command
 	// netsh advfirewall firewall add rule name="..." dir=in/out action=allow
-	//   remoteip=... localip=any protocol=any interface="wg-nb-machine"
+	//   remoteip=... localip=any protocol=any interfacetype=any
+	// Note: netsh 'add rule' does not support the 'group' parameter -
+	// that is only available via PowerShell's New-NetFirewallRule.
+	// Rules are identified by name prefix (NetBird-Machine-) for cleanup.
 	args := []string{
 		"advfirewall", "firewall", "add", "rule",
 		fmt.Sprintf("name=%s", ruleName),
@@ -76,7 +78,6 @@ func (m *FirewallManager) addRule(ruleName, direction, remoteIP string) error {
 		"localip=any",
 		"protocol=any",
 		"interfacetype=any",
-		fmt.Sprintf("group=%s", FirewallGroupName),
 	}
 
 	cmd := exec.Command("netsh", args...)
@@ -123,7 +124,6 @@ func (m *FirewallManager) EnableDenyDefault() error {
 		"localip=any",
 		"remoteip=any",
 		"protocol=any",
-		fmt.Sprintf("group=%s", FirewallGroupName),
 	}
 
 	cmd := exec.Command("netsh", argsIn...)
@@ -141,7 +141,6 @@ func (m *FirewallManager) EnableDenyDefault() error {
 		"localip=any",
 		"remoteip=any",
 		"protocol=any",
-		fmt.Sprintf("group=%s", FirewallGroupName),
 	}
 
 	cmd = exec.Command("netsh", argsOut...)
@@ -154,37 +153,44 @@ func (m *FirewallManager) EnableDenyDefault() error {
 	return nil
 }
 
-// RemoveAllRules removes all Machine Tunnel firewall rules
+// RemoveAllRules removes all Machine Tunnel firewall rules.
+// Since netsh 'delete rule' does not support the 'group' parameter,
+// we enumerate rules by name prefix and delete each individually.
 func (m *FirewallManager) RemoveAllRules() error {
 	log.Info("Removing all Machine Tunnel firewall rules")
 
-	// Delete rules by group name
-	args := []string{
-		"advfirewall", "firewall", "delete", "rule",
-		fmt.Sprintf("group=%s", FirewallGroupName),
-	}
-
-	cmd := exec.Command("netsh", args...)
-	output, err := cmd.CombinedOutput()
+	rules, err := m.ListRules()
 	if err != nil {
-		// Check if error is "No rules match the specified criteria"
-		outputStr := string(output)
-		if strings.Contains(outputStr, "No rules match") {
-			log.Debug("No firewall rules to remove")
-			return nil
-		}
-		return fmt.Errorf("netsh delete rules failed: %w, output: %s", err, outputStr)
+		return fmt.Errorf("list rules for cleanup: %w", err)
 	}
 
-	log.Info("All Machine Tunnel firewall rules removed")
+	if len(rules) == 0 {
+		log.Debug("No firewall rules to remove")
+		return nil
+	}
+
+	var errs []string
+	for _, ruleName := range rules {
+		if err := m.deleteRule(ruleName); err != nil {
+			errs = append(errs, fmt.Sprintf("delete %s: %v", ruleName, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete some rules: %s", strings.Join(errs, "; "))
+	}
+
+	log.WithField("count", len(rules)).Info("All Machine Tunnel firewall rules removed")
 	return nil
 }
 
-// ListRules lists all Machine Tunnel firewall rules
+// ListRules lists all Machine Tunnel firewall rules.
+// Uses 'show rule name=all' and filters by name prefix since
+// netsh 'show rule' does not support the 'group' parameter.
 func (m *FirewallManager) ListRules() ([]string, error) {
 	args := []string{
 		"advfirewall", "firewall", "show", "rule",
-		fmt.Sprintf("group=%s", FirewallGroupName),
+		"name=all",
 	}
 
 	cmd := exec.Command("netsh", args...)
@@ -197,7 +203,7 @@ func (m *FirewallManager) ListRules() ([]string, error) {
 		return nil, fmt.Errorf("netsh show rules failed: %w, output: %s", err, outputStr)
 	}
 
-	// Parse output to extract rule names
+	// Parse output to extract rule names matching our prefix
 	var rules []string
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {

--- a/client/internal/tunnel/machine.go
+++ b/client/internal/tunnel/machine.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/netbirdio/netbird/client/iface"
 	"github.com/netbirdio/netbird/client/internal/auth"
+	"github.com/netbirdio/netbird/client/internal/ntp"
 	"github.com/netbirdio/netbird/client/internal/profilemanager"
 	"github.com/netbirdio/netbird/client/internal/routemanager/systemops"
 	"github.com/netbirdio/netbird/client/ssh"
@@ -520,6 +521,23 @@ func (t *MachineTunnel) persistKeys(managementURL, wgKey, sshKey, setupKey strin
 func (t *MachineTunnel) connect() error {
 	log.Info("Machine Tunnel connecting...")
 
+	// Step 0: Clean up stale resources from previous sessions (e.g. after crash).
+	// After a forced service termination (taskkill /f), the cleanup handler doesn't run,
+	// leaving firewall deny-default rules that block management server connectivity.
+	t.cleanupStaleResources()
+
+	// Step 0.5: Ensure time is synchronized before mTLS/TLS authentication (T-4.7).
+	// Time drift causes TLS handshake failures. Uses public NTP (pre-tunnel).
+	ntpMgr, err := ntp.NewManager(&ntp.ManagerConfig{})
+	if err != nil {
+		log.WithError(err).Warn("Failed to create NTP manager, skipping time sync check")
+	} else {
+		if err := ntpMgr.EnsureTimeSync(t.ctx); err != nil {
+			log.WithError(err).Warn("NTP time sync failed, continuing with local time")
+		}
+		ntpMgr.Close()
+	}
+
 	// Step 1: Bootstrap - authenticate and get peer configuration
 	machineConfig, err := t.toMachineConfig()
 	if err != nil {
@@ -638,18 +656,13 @@ func (t *MachineTunnel) setupWireGuardInterface(result *BootstrapResult, machine
 
 // configureNRPT sets up Name Resolution Policy Table rules for AD DNS
 func (t *MachineTunnel) configureNRPT(result *BootstrapResult) error {
-	if result.DNSConfig == nil {
-		log.Debug("No DNS config in bootstrap result, skipping NRPT")
-		return nil
-	}
-
 	log.Info("Configuring NRPT rules for AD DNS routing")
 
-	// Extract DNS servers and namespaces from config
+	// Extract DNS servers and namespaces from config file first,
+	// then fall back to bootstrap result
 	var dnsServers []string
 	var namespaces []string
 
-	// Use config from bootstrap result or fall back to MachineTunnelConfig
 	if len(t.config.DNSServers) > 0 {
 		dnsServers = t.config.DNSServers
 	}
@@ -657,8 +670,9 @@ func (t *MachineTunnel) configureNRPT(result *BootstrapResult) error {
 		namespaces = t.config.DNSNamespaces
 	}
 
-	if len(dnsServers) == 0 || len(namespaces) == 0 {
-		log.Debug("No DNS servers or namespaces configured, skipping NRPT")
+	// If not configured, try bootstrap result
+	if (len(dnsServers) == 0 || len(namespaces) == 0) && result.DNSConfig == nil {
+		log.Debug("No DNS servers or namespaces configured and no DNS config in bootstrap result, skipping NRPT")
 		return nil
 	}
 
@@ -1218,6 +1232,22 @@ func (t *MachineTunnel) maintainConnection() {
 		log.Info("Connection maintenance stopped: context cancelled")
 	case <-t.unhealthyCh:
 		log.Warn("Connection maintenance stopped: health check failed")
+	}
+}
+
+// cleanupStaleResources removes leftover NRPT and firewall rules from a previous
+// session that didn't shut down cleanly (e.g. after taskkill /f or system crash).
+// This ensures the deny-default firewall rules don't block management server connectivity
+// during the new bootstrap sequence.
+func (t *MachineTunnel) cleanupStaleResources() {
+	nrptMgr := NewNRPTManager()
+	if err := nrptMgr.RemoveAllRules(); err != nil {
+		log.WithError(err).Warn("Failed to clean up stale NRPT rules")
+	}
+
+	fwMgr := NewFirewallManager(t.config.InterfaceName)
+	if err := fwMgr.RemoveAllRules(); err != nil {
+		log.WithError(err).Warn("Failed to clean up stale firewall rules")
 	}
 }
 

--- a/client/internal/tunnel/nrpt_windows.go
+++ b/client/internal/tunnel/nrpt_windows.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
@@ -82,8 +83,9 @@ func (m *NRPTManager) AddRule(namespace string, dnsServers []string) error {
 		return fmt.Errorf("failed to set Name: %w", err)
 	}
 
-	// Set GenericDNSServers (REG_MULTI_SZ - DC IPs)
-	if err := ruleKey.SetStringsValue("GenericDNSServers", dnsServers); err != nil {
+	// Set GenericDNSServers (REG_SZ - semicolon-separated DNS server IPs)
+	// Windows NRPT expects this as REG_SZ, not REG_MULTI_SZ
+	if err := ruleKey.SetStringValue("GenericDNSServers", strings.Join(dnsServers, ";")); err != nil {
 		return fmt.Errorf("failed to set GenericDNSServers: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes multiple issues blocking S-4 (Windows Client Service) task completion:

- **NRPT (T-4.4, #39/#40)**: Remove early return on nil `DNSConfig` so config-file-based `dns_servers`/`dns_namespaces` are used. Fix `GenericDNSServers` registry type from `REG_MULTI_SZ` to `REG_SZ`.
- **Firewall (T-4.5 #41, T-4.6 #43)**: Remove invalid `group` parameter from `netsh add/delete/show rule` commands. Use name-prefix-based rule enumeration for cleanup instead.
- **Crash Recovery (T-4.8, #45)**: Add `cleanupStaleResources()` at `connect()` start to remove leftover deny-default firewall rules that block management server after unclean shutdown.
- **NTP Sync (T-4.7, #44)**: Integrate `ntp.EnsureTimeSync()` before bootstrap to detect time drift before mTLS authentication.

## Evidence (Windows VM 10.0.0.160)

### NRPT Rules
```
Namespace   : {._msdcs.test.local}
NameServers : 192.168.100.20
Comment     : NetBird Machine Tunnel (Namespace: ._msdcs.test.local)

Namespace   : {.test.local}
NameServers : 192.168.100.20
Comment     : NetBird Machine Tunnel (Namespace: .test.local)
```

### Firewall Rules
```
DisplayName                                 Action Direction Enabled
NetBird-Machine-allow-192_168_100_20-32-in   Allow   Inbound    True
NetBird-Machine-allow-192_168_100_20-32-out  Allow  Outbound    True
NetBird-Machine-deny-default-in              Block   Inbound    True
NetBird-Machine-deny-default-out             Block  Outbound    True
```

### Cleanup on Stop
```
Firewall rules after stop: 0
NRPT rules after stop: 0
```

### SCM Crash Recovery
```
Before crash: Running, 4 firewall rules
After crash (1s): Stopped, 4 stale rules (no cleanup ran)
After SCM restart (12s): Running (stale rules cleaned, reconnected)
```

### NTP Integration
```
INFO [phase: pre-tunnel] ntp/sync.go:162: Checking time synchronization
WARN ntp/sync.go:168: Failed to check time offset from public NTP  (expected in lab)
INFO ntp/sync.go:284: NTP manager closed
INFO [auth_method: SetupKey, peer_ip: ...] tunnel/machine.go:555: Bootstrap successful
```

## Test plan
- [x] Windows build succeeds
- [x] golangci-lint: 0 issues
- [x] NRPT rules created with hash-based key names
- [x] Firewall allow + deny-default rules created
- [x] Cleanup removes all rules on service stop
- [x] SCM recovery restarts service after crash
- [x] Stale rules cleaned before reconnect
- [x] NTP check runs pre-tunnel (non-fatal on failure)
- [ ] CI checks pass

Closes #39, #40, #41, #43, #44, #45

- [x] Documentation is **not needed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)