### PR TITLE
fix(ci): skip Docker Hub login when credentials are not configured

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -352,7 +352,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -363,7 +363,7 @@ jobs:
         run: docker pull mlsmaycon/warmed-mysql:8
 
       - name: Test
-        run: |          
+        run: |
           CGO_ENABLED=1 GOARCH=${{ matrix.arch }} \
           NETBIRD_STORE_ENGINE=${{ matrix.store }} \
             CI=true \
@@ -440,7 +440,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -529,7 +529,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
## Summary

- Fix `Management / Unit (amd64, mysql)` failure on `main` push: Docker login step fails with "Username and password required" because `DOCKER_USER`/`DOCKER_TOKEN` secrets are not configured in the fork
- Add `secrets.DOCKER_USER != ''` guard to all 3 Docker login steps in `golang-test-linux.yml`
- MySQL image pull still works without auth (public image)

## Root Cause

Upstream NetBird has Docker Hub credentials as repo secrets. Our fork doesn't, causing the `docker/login-action` to fail on every `main` push for MySQL-related jobs.

## Test Plan

- [x] Verify MySQL tests still pass without Docker Hub login (public image pull)
- [ ] CI passes on this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)