### PR TITLE
fix(ci): use env vars instead of secrets in step-if conditions

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  HAS_DOCKER_CREDS: ${{ secrets.DOCKER_USER != '' }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
@@ -355,7 +358,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -443,7 +446,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -532,7 +535,7 @@ jobs:
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && secrets.DOCKER_USER != '' && (github.repository == github.head.repo.full_name || !github.head_ref)
+        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ env:
   GORELEASER_VER: "v2.3.2"
   PRODUCT_NAME: "NetBird"
   COPYRIGHT: "NetBird GmbH"
+  HAS_DOCKER_CREDS: ${{ secrets.DOCKER_USER != '' }}
+  HAS_GHCR_CREDS: ${{ secrets.CI_DOCKER_PUSH_GITHUB_TOKEN != '' }}
 
 permissions:
   contents: write
@@ -157,13 +159,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Log in to the GitHub container registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && env.HAS_GHCR_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary

- **Fix golang-test-linux.yml "workflow file issue"**: The `secrets` context is [not available](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) in step-level `if` conditions. This caused every push event to fail with "workflow file issue" (0 jobs, 0s) since the fork was created. Fix: Move `secrets.DOCKER_USER != ''` to a workflow-level `env` variable (`HAS_DOCKER_CREDS`) and reference via `env.HAS_DOCKER_CREDS == 'true'` in step `if`.
- **Fix release.yml Docker Hub login failure**: Docker Hub and GHCR login steps now check for credential availability before attempting login, preventing runtime failures on push events.
- Also removes invalid `github.head.repo.full_name` expression (not a valid GitHub context property).

## Root Cause

PR #141 introduced `secrets.DOCKER_USER != ''` in step-level `if` conditions. According to [GitHub Actions context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), `secrets` is only available in `env`, `with`, and `run` — **not** in step `if`. Confirmed by `actionlint`.

## Verification

```
$ actionlint .github/workflows/golang-test-linux.yml
# Before: 8 errors (3x secrets in if, 3x github.head.repo, 2x steps.cache)
# After: 2 warnings (pre-existing upstream steps.cache references - harmless)

$ actionlint .github/workflows/release.yml
# Before: 0 errors (no secrets in if)
# After: 0 errors
```

## Test plan

- [ ] PR CI checks pass (pull_request event)
- [ ] After merge: push event to main triggers Linux workflow with actual jobs (not "workflow file issue")
- [ ] Release workflow push event skips Docker login gracefully

Closes #32, Closes #33