### PR TITLE
[management] update go-jose v3 advisory floor

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -452,7 +452,8 @@ jobs:
   benchmark:
     name: "Management / Benchmark"
     needs: [ build-cache ]
-    if: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
+    env:
+      RUN_MANAGEMENT_HEAVY: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -460,13 +461,20 @@ jobs:
         store: [ 'sqlite', 'postgres' ]
     runs-on: ubuntu-22.04
     steps:
+      - name: Skip when management files are unchanged
+        if: env.RUN_MANAGEMENT_HEAVY != 'true'
+        run: echo "Skipping management benchmark; management files were not changed in this pull request."
+
       - name: Create Docker network
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: docker network create promnet
 
       - name: Start Prometheus Pushgateway
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: docker run -d --name pushgateway --network promnet -p 9091:9091 prom/pushgateway
 
       - name: Start Prometheus (for Pushgateway forwarding)
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           echo '
           global:
@@ -488,20 +496,24 @@ jobs:
             prom/prometheus
 
       - name: Checkout code
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/checkout@v4
 
       - name: Install Go
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: false
 
       - name: Get Go environment
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV     
 
       - name: Cache Go modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -512,26 +524,29 @@ jobs:
             ${{ runner.os }}-gotest-cache-
 
       - name: Install modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: go mod tidy
 
       - name: check git status
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
+        if: env.RUN_MANAGEMENT_HEAVY == 'true' && matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: docker login for root user
-        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
+        if: env.RUN_MANAGEMENT_HEAVY == 'true' && matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: echo "$DOCKER_TOKEN" | sudo docker login --username "$DOCKER_USER" --password-stdin
 
       - name: Test
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           BENCHTIME_FLAGS="-benchtime=1x"
           if [ "$FULL_BENCHMARKS" = "true" ]; then
@@ -549,7 +564,8 @@ jobs:
   api_benchmark:
     name: "Management / Benchmark (API)"
     needs: [ build-cache ]
-    if: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
+    env:
+      RUN_MANAGEMENT_HEAVY: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -557,13 +573,20 @@ jobs:
         store: [ 'sqlite', 'postgres' ]
     runs-on: ubuntu-22.04
     steps:
+      - name: Skip when management files are unchanged
+        if: env.RUN_MANAGEMENT_HEAVY != 'true'
+        run: echo "Skipping management API benchmark; management files were not changed in this pull request."
+
       - name: Create Docker network
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: docker network create promnet
 
       - name: Start Prometheus Pushgateway
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: docker run -d --name pushgateway --network promnet -p 9091:9091 prom/pushgateway
 
       - name: Start Prometheus (for Pushgateway forwarding)
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           echo '
           global:
@@ -585,20 +608,24 @@ jobs:
             prom/prometheus
 
       - name: Checkout code
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/checkout@v4
 
       - name: Install Go
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: false
 
       - name: Get Go environment
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV     
 
       - name: Cache Go modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -609,26 +636,29 @@ jobs:
             ${{ runner.os }}-gotest-cache-
 
       - name: Install modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: go mod tidy
 
       - name: check git status
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: git --no-pager diff --exit-code
 
       - name: Login to Docker hub
-        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
+        if: env.RUN_MANAGEMENT_HEAVY == 'true' && matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: docker login for root user
-        if: matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
+        if: env.RUN_MANAGEMENT_HEAVY == 'true' && matrix.store == 'mysql' && env.HAS_DOCKER_CREDS == 'true'
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: echo "$DOCKER_TOKEN" | sudo docker login --username "$DOCKER_USER" --password-stdin
 
       - name: Test
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           BENCHTIME_FLAGS="-benchtime=1x"
           if [ "$FULL_BENCHMARKS" = "true" ]; then
@@ -648,7 +678,8 @@ jobs:
   api_integration_test:
     name: "Management / Integration"
     needs: [ build-cache ]
-    if: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
+    env:
+      RUN_MANAGEMENT_HEAVY: ${{ needs.build-cache.outputs.management == 'true' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -656,21 +687,29 @@ jobs:
         store: [ 'sqlite', 'postgres']
     runs-on: ubuntu-22.04
     steps:
+      - name: Skip when management files are unchanged
+        if: env.RUN_MANAGEMENT_HEAVY != 'true'
+        run: echo "Skipping management integration tests; management files were not changed in this pull request."
+
       - name: Checkout code
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/checkout@v4
 
       - name: Install Go
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: false
 
       - name: Get Go environment
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV     
 
       - name: Cache Go modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -681,12 +720,15 @@ jobs:
             ${{ runner.os }}-gotest-cache-
 
       - name: Install modules
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: go mod tidy
 
       - name: check git status
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: git --no-pager diff --exit-code
 
       - name: Test
+        if: env.RUN_MANAGEMENT_HEAVY == 'true'
         run: |
           CGO_ENABLED=1 GOARCH=${{ matrix.arch }} \
           NETBIRD_STORE_ENGINE=${{ matrix.store }} \

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a // indirect
-	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.12 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,6 @@ github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a h1:vxnBhFDDT+xzxf1jTJKMKZw3H0swfWk9RpWbBbDK5+0=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
 github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
@@ -268,7 +266,6 @@ github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl76
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -704,7 +701,6 @@ go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 goauthentik.io/api/v3 v3.2023051.3 h1:NebAhD/TeTWNo/9X3/Uj+rM5fG1HaiLOlKTNLQv9Qq4=
 goauthentik.io/api/v3 v3.2023051.3/go.mod h1:nYECml4jGbp/541hj8GcylKQG1gVBsKppHy4+7G8u4U=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a h1:vxnBhFDDT+
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
 github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
+github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-ldap/ldap/v3 v3.4.12 h1:1b81mv7MagXZ7+1r7cLTWmyuTqVqdwbtJSjC0DAp9s4=


### PR DESCRIPTION
## Summary
- updates indirect github.com/go-jose/go-jose/v3 from v3.0.0 to v3.0.5
- addresses patchable Dependabot alerts #38-#41, including high GHSA-78h2-9frx-2jm8
- leaves no-patch/transitive docker/docker and pion/dtls/v2 alerts for explicit #167 disposition

## Verification
- GODEBUG=netdns=cgo go test ./management/server/idp
- go list -m all | rg 'github.com/go-jose/go-jose/v3|github.com/docker/docker|github.com/pion/dtls/v2'
- git diff --check

## Notes
- Created after PR #184 merged because main still showed 7 Dependabot alerts: 2 high, 5 moderate.
