### PR TITLE
[infrastructure] re-enable CodeQL pull request scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "22 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Re-enable CodeQL on `pull_request` after the default-branch baseline has been established and the remaining critical/high finding has a recorded disposition in #170.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "YAML OK"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql.yml`
- `git diff --check`

## Context

- Main CodeQL baseline after PR #185: open code scanning alerts are `142 medium`, `2 warning`, `0 critical`, `0 high`.
- CodeQL alert #11 was dismissed as accepted inherited upstream OIDC issuer validation risk and documented in #170.
- After this PR proves stable, add `CodeQL (go)` and `CodeQL (javascript-typescript)` to branch protection required checks.

Refs #170
