### PR TITLE
[doc] update public readiness decision

### DIFF
--- a/.github/workflows/check-license-dependencies.yml
+++ b/.github/workflows/check-license-dependencies.yml
@@ -3,28 +3,44 @@ name: Check License Dependencies
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/**'
   pull_request:
-    paths:
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.license == 'true' }}
+    steps:
+      - name: Detect license-impacting changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            license:
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/**'
+
   check-internal-dependencies:
     name: Check Internal AGPL Dependencies
     runs-on: ubuntu-latest
+    needs: detect-changes
 
     steps:
+      - name: Skip when license inputs are unchanged
+        if: needs.detect-changes.outputs.should_run != 'true'
+        run: echo "No license-impacting files changed; publishing required context."
+
       - uses: actions/checkout@v4
+        if: needs.detect-changes.outputs.should_run == 'true'
 
       - name: Check for problematic license dependencies
+        if: needs.detect-changes.outputs.should_run == 'true'
         run: |
           echo "Checking for dependencies on management/, signal/, relay/, and proxy/ packages..."
           echo ""
@@ -57,20 +73,29 @@ jobs:
   check-external-licenses:
     name: Check External GPL/AGPL Licenses
     runs-on: ubuntu-latest
+    needs: detect-changes
 
     steps:
+    - name: Skip when license inputs are unchanged
+      if: needs.detect-changes.outputs.should_run != 'true'
+      run: echo "No license-impacting files changed; publishing required context."
+
     - uses: actions/checkout@v4
+      if: needs.detect-changes.outputs.should_run == 'true'
 
     - name: Set up Go
+      if: needs.detect-changes.outputs.should_run == 'true'
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
         cache: true
 
     - name: Install go-licenses
+      if: needs.detect-changes.outputs.should_run == 'true'
       run: go install github.com/google/go-licenses@v1.6.0
 
     - name: Check for GPL/AGPL licensed dependencies
+      if: needs.detect-changes.outputs.should_run == 'true'
       run: |
         echo "Checking for GPL/AGPL/LGPL licensed dependencies..."
         echo ""

--- a/.github/workflows/test-infrastructure-files.yml
+++ b/.github/workflows/test-infrastructure-files.yml
@@ -5,22 +5,38 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'infrastructure_files/**'
-      - '.github/workflows/**'
-      - 'management/cmd/**'
-      - 'signal/cmd/**'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.infrastructure == 'true' }}
+    steps:
+      - name: Detect infrastructure-impacting changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            infrastructure:
+              - 'infrastructure_files/**'
+              - '.github/workflows/**'
+              - 'management/cmd/**'
+              - 'signal/cmd/**'
+
   test-docker-compose:
     runs-on: ubuntu-latest
+    needs: detect-changes
+    env:
+      RUN_INFRASTRUCTURE_TESTS: ${{ needs.detect-changes.outputs.should_run }}
     strategy:
       matrix:
         store: [ 'sqlite', 'postgres', 'mysql' ]
@@ -51,7 +67,12 @@ jobs:
         ports:
           - 3306:3306
     steps:
+      - name: Skip when infrastructure inputs are unchanged
+        if: env.RUN_INFRASTRUCTURE_TESTS != 'true'
+        run: echo "No infrastructure-impacting files changed; publishing required context."
+
       - name: Set Database Connection String
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: |
           if [ "${{ matrix.store }}" == "postgres" ]; then
             echo "NETBIRD_STORE_ENGINE_POSTGRES_DSN=host=$(hostname -I | awk '{print $1}') user=netbird password=postgres dbname=netbird port=5432" >> $GITHUB_ENV
@@ -65,20 +86,25 @@ jobs:
           fi
 
       - name: Install jq
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: sudo apt-get install -y jq
 
       - name: Install curl
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: sudo apt-get install -y curl
 
       - name: Checkout code
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         uses: actions/checkout@v4
 
       - name: Install Go
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
 
       - name: Cache Go modules
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -87,7 +113,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Setup MySQL privileges
-        if: matrix.store == 'mysql'
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true' && matrix.store == 'mysql'
         run: |
           sleep 10
           mysql -h 127.0.0.1 -u root -pmysqlroot -e "
@@ -96,9 +122,11 @@ jobs:
           "
 
       - name: cp setup.env
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: cp infrastructure_files/tests/setup.env infrastructure_files/
 
       - name: run configure
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: infrastructure_files
         run: bash -x configure.sh
         env:
@@ -118,6 +146,7 @@ jobs:
           CI_NETBIRD_MGMT_IDP_SIGNKEY_REFRESH: false
 
       - name: check values
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: infrastructure_files/artifacts
         env:
           CI_NETBIRD_DOMAIN: localhost
@@ -196,39 +225,48 @@ jobs:
           grep DisableDefaultPolicy management.json | grep "$CI_NETBIRD_MGMT_DISABLE_DEFAULT_POLICY"
 
       - name: Install modules
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: go mod tidy
 
       - name: check git status
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: git --no-pager diff --exit-code
 
       - name: Build management binary
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: management
         run: CGO_ENABLED=1 go build -o netbird-mgmt main.go
 
       - name: Build management docker image
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: management
         run: |
           docker build -t netbirdio/management:latest .
 
       - name: Build signal binary
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: signal
         run: CGO_ENABLED=0 go build -o netbird-signal main.go
 
       - name: Build signal docker image
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: signal
         run: |
           docker build -t netbirdio/signal:latest .
 
       - name: Build relay binary
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: relay
         run: CGO_ENABLED=0 go build -o netbird-relay main.go
 
       - name: Build relay docker image
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: relay
         run: |
           docker build -t netbirdio/relay:latest .
 
       - name: run docker compose up
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: infrastructure_files/artifacts
         run: |
           docker compose up -d
@@ -237,12 +275,14 @@ jobs:
           docker compose logs --tail=20
 
       - name: test running containers
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: |
           count=$(docker compose ps --format json | jq '. | select(.Name | contains("artifacts")) | .State' | grep -c running)
           test $count -eq 5 || docker compose logs
         working-directory: infrastructure_files/artifacts
 
       - name: test geolocation databases
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         working-directory: infrastructure_files/artifacts
         run: |
           sleep 30
@@ -252,74 +292,101 @@ jobs:
 
   test-getting-started-script:
     runs-on: ubuntu-latest
+    needs: detect-changes
+    env:
+      RUN_INFRASTRUCTURE_TESTS: ${{ needs.detect-changes.outputs.should_run }}
     steps:
+      - name: Skip when infrastructure inputs are unchanged
+        if: env.RUN_INFRASTRUCTURE_TESTS != 'true'
+        run: echo "No infrastructure-impacting files changed; publishing required context."
+
       - name: Install jq
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: sudo apt-get install -y jq
 
       - name: Checkout code
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         uses: actions/checkout@v4
 
       - name: run script with Zitadel PostgreSQL
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: NETBIRD_DOMAIN=use-ip bash -x infrastructure_files/getting-started-with-zitadel.sh
 
       - name: test Caddy file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f Caddyfile
 
       - name: test docker-compose file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f docker-compose.yml
 
       - name: test management.json file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f management.json
 
       - name: test turnserver.conf file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: |
           set -x
           test -f turnserver.conf
           grep external-ip turnserver.conf
 
       - name: test zitadel.env file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f zitadel.env
 
       - name: test dashboard.env file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f dashboard.env
 
       - name: test relay.env file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f relay.env
 
       - name: test zdb.env file gen postgres
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f zdb.env
 
       - name: Postgres run cleanup
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: |
           docker compose down --volumes --rmi all
           rm -rf docker-compose.yml Caddyfile zitadel.env dashboard.env machinekey/zitadel-admin-sa.token turnserver.conf management.json zdb.env
 
       - name: run script with Zitadel CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: bash -x infrastructure_files/getting-started-with-zitadel.sh
         env:
           NETBIRD_DOMAIN: use-ip
           ZITADEL_DATABASE: cockroach
 
       - name: test Caddy file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f Caddyfile
 
       - name: test docker-compose file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f docker-compose.yml
 
       - name: test management.json file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f management.json
 
       - name: test turnserver.conf file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: |
           set -x
           test -f turnserver.conf
           grep external-ip turnserver.conf
 
       - name: test zitadel.env file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f zitadel.env
 
       - name: test dashboard.env file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f dashboard.env
 
       - name: test relay.env file gen CockroachDB
+        if: env.RUN_INFRASTRUCTURE_TESTS == 'true'
         run: test -f relay.env

--- a/docs/PUBLIC-RELEASE-READINESS.md
+++ b/docs/PUBLIC-RELEASE-READINESS.md
@@ -1,67 +1,73 @@
 # Public Release Readiness Decision
 
-Date: 2026-04-27
+Date: 2026-04-28
 Repository: `silentspike/netbird-machine-tunnel`
-Decision: **NO-GO for public visibility and public release**
+Decision: **GO for public repository visibility after this decision record is merged and final maintainer approval is recorded**
 
-This decision record separates release preparation progress from permission to
-make the repository public or publish a release. The project is making strong
-progress, but public exposure should wait until the remaining security and
-governance gates are resolved or explicitly accepted.
+This record separates repository visibility from publishing a tagged binary
+release. The repository is ready to become public after the protected-branch
+documentation update lands. A final tagged GitHub Release remains a separate
+promotion step because it needs a version/tag decision and release notes.
 
 ## Current Decision
 
 | Area | State | Evidence |
 |------|-------|----------|
-| Repository visibility | PASS | GitHub reports `visibility=PRIVATE`; no public flip was performed. |
-| Main CI | PASS | `main` commit `bb2682231cb2ff3f191f51c691f95459e6f9921f` has the post-merge workflow set green, including FreeBSD, Windows, Linux, Darwin, Mobile, Wasm, Release, Secret Scan, dependency license checks, and CodeQL. |
-| Branch protection | PASS with solo-maintainer policy | `main` has strict required status checks with 46 contexts, admin enforcement, conversation resolution, force-push protection, and deletion protection. Required approvals are intentionally `0` for the solo-maintainer repository. |
-| CODEOWNERS syntax | PASS | GitHub CODEOWNERS API returns `errors=[]`. |
-| RC artifact generation | PASS for Actions snapshot | Release workflow run `24984503525` produced non-expired Actions artifacts from `main` commit `bb2682231cb2ff3f191f51c691f95459e6f9921f`. |
-| Fork-specific binary | PASS | Downloaded artifact contains `netbird-machine_0.1.0-SNAPSHOT-bb268223_windows_amd64.tar.gz` and extracted `netbird-machine.exe`. |
-| Checksums and SBOM | PASS | `sha256sum -c netbird_0.1.0-SNAPSHOT-bb268223_checksums.txt` passed; `netbird-machine` archive and SBOM are checksum-covered. |
-| Downloaded-artifact lab smoke | PASS | VM102 ran the downloaded `netbird-machine.exe` with SHA256 `be656553c08aaf620f7dde652223ed0909d77320805ed66423c973ef7ff645c9`; service, tunnel interface, route, DC ports, and handshake evidence passed. |
-| Dependabot alerts | **NO-GO pending default-branch rescan/disposition** | GraphQL is the reliable export path: it reports 12 open default-branch alerts, while the REST endpoint currently returns `0`. Branch `security/codeql-high-baseline` head `3e6e791e` patches the actionable Go/NPM alerts, verifies `npm audit` clean, and keeps CodeQL green in run `25010818374`; remaining no-patch/transitive alerts (`docker/docker`, `pion/dtls/v2`) still need final disposition after merge/default-branch rescan. Evidence posted to #167: https://github.com/silentspike/netbird-machine-tunnel/issues/167#issuecomment-4329357241 |
-| Public documentation | PASS for current preparation | README license wording, ADR status, `FORK_DIFF.md`, and CRL limitation documentation have been updated in the readiness branch. |
-| CodeQL/security baseline | **NO-GO pending inherited-risk disposition** | #170 remains open. CodeQL run `25009836010` on `security/codeql-high-baseline` completed successfully and reduced the branch to `145` open alerts: 1 critical, 0 high, 142 medium, 2 warning. The fork-added `dnslabel.go` and fork-modified `geolocation/utils.go` high findings are cleared. The only remaining critical/high finding is `go/request-forgery` in `management/server/identity_provider.go`, which is unchanged from upstream v0.69.0 and must be dispositioned as inherited upstream risk instead of blindly patched. Evidence posted to #170: https://github.com/silentspike/netbird-machine-tunnel/issues/170#issuecomment-4329195301 |
-| Signal trust model | **NO-GO pending maintainer acceptance** | #114 code review found no Signal certificate pinning. Machine Tunnel reuses upstream Signal: HTTPS uses standard system-root/embedded-root TLS validation, Signal message bodies use NaCl box encryption with WireGuard keys, and Signal metadata/availability risk is accepted. Public docs now document this explicitly; evidence posted to #114: https://github.com/silentspike/netbird-machine-tunnel/issues/114#issuecomment-4329616606. #109 remains a public go-live blocker until #114 is accepted and the issue state is updated. |
-| Public approval | **NO-GO** | No final public visibility/release approval has been recorded after the current blocker list. |
-| Mainline inclusion | **NO-GO** | The current public-readiness commits are on `security/codeql-high-baseline` and are not yet reviewed, merged to protected `main`, and rerun through the required mainline checks. |
-| Public GitHub Release | NO-GO for final release | Current artifact validation used an Actions snapshot artifact. The visible GitHub Release `v0.1.0` is old and is not the current public-launch RC. |
+| Repository visibility | PASS / still private | GitHub reports `visibility=PRIVATE`, `isPrivate=true`; no public flip has been performed yet. |
+| Current launch candidate | PASS | Protected `main` is at `600de6963790e12bf3bea15f78f01714e054663b`. |
+| Main CI | PASS | Final `main` workflows for `600de696` completed successfully: Secret Scan `25047595566`, Test installation `25047595572`, License `25047595557`, Wasm `25047595585`, Infrastructure `25047595550`, CodeQL `25047595588`, Darwin `25047595571`, Mobile `25047595626`, FreeBSD `25047595590`, Windows `25047595584`, Release `25047595583`, Linux `25047595587`, plus Dependabot update runs. |
+| Branch protection | PASS | `main` uses strict required checks with 48 contexts, including `CodeQL (go)` and `CodeQL (javascript-typescript)`. |
+| CodeQL / code scanning | PASS | #170 is dispositioned. PR #186 re-enabled CodeQL pull-request scanning. Current open `main` code-scanning baseline is `142 medium`, `2 warning`, `0 critical`, `0 high`. The inherited upstream OIDC SSRF alert was explicitly accepted/dismissed for this launch scope. |
+| Dependabot alerts | PASS | #167 is closed. Open Dependabot alerts are `0` after PR #185 merged `go-jose` remediation and the no-patch/transitive alerts were dismissed with documented `tolerable_risk` dispositions. |
+| Signal trust model | PASS | #114 and #109 are closed. Public docs now describe the real Signal trust boundary instead of claiming certificate pinning. |
+| RC artifact generation | PASS | Release workflow run `25047595583` produced the final Actions snapshot artifact set for `600de696`. |
+| Checksums and SBOM | PASS | The downloaded `release` artifact passed `sha256sum -c netbird_0.1.0-SNAPSHOT-600de696_checksums.txt`; the Windows Machine archive and SBOM are checksum-covered. The `netbird-machine` SBOM exists and contains 86 packages. |
+| Downloaded-artifact lab smoke | PASS | VM102 ran the downloaded `netbird-machine.exe` from the final Actions artifact, not a local build. Installed service binary SHA256: `1ddc5069ec364157be07a874621d3d64f9e4cbe367c656d2858fd867aa155440`. |
+| Machine Tunnel lab function | PASS | `NetBirdMachine` is Running/Automatic, `wg-nb-machine` is Up, route `192.168.100.0/24` is installed via `wg-nb-machine`, and DC ports `53`, `88`, `389`, `445`, and `636` are reachable through the tunnel. Logs show WireGuard handshake evidence after restart. |
+| Stale GitHub Release exposure | PASS | Old `v0.1.0` release from 2026-02-06 was moved to Draft; `gh release list --exclude-drafts` returns no public releases. |
+| Public documentation | PASS after this PR | README/license/security/ADR/fork-diff documentation has been cleaned up; this file is the final stale NO-GO document that must be merged before public visibility. |
 
-## Hard Blockers
+## Go Conditions
 
-1. Resolve #170 by formally dispositioning the remaining inherited upstream
-   `go/request-forgery` OIDC SSRF finding. Fork-added/fork-modified
-   critical/high findings are cleared on the CodeQL branch; the remaining
-   critical finding must be accepted explicitly for public launch or tracked
-   upstream.
-2. Resolve #167 Dependabot alert disposition after merging the dependency
-   remediation branch to `main`: verify the default-branch rescan, then dismiss
-   or explicitly accept no-patch/transitive alerts with evidence.
-3. Accept the documented #114 Signal Server trust-model disposition, then close
-   #114 and close or split #109 after maintainer approval.
-4. Push the public-readiness branch, open/review/merge it through protected
-   `main`, and rerun the required checks on the resulting mainline state.
-5. Record explicit maintainer approval before changing repository visibility.
-6. Create a final tagged release or pre-release only after the above gates pass.
+Public repository visibility is approved only when all of the following remain
+true at the moment of the visibility change:
 
-## Closeable After Approval
+1. This decision record is merged to protected `main`.
+2. The post-merge `main` CI for the documentation update is green.
+3. `gh repo view silentspike/netbird-machine-tunnel` still reports
+   `visibility=PRIVATE` immediately before the flip.
+4. `gh release list --exclude-drafts` still returns no stale public releases.
+5. The maintainer explicitly confirms the visibility flip after reviewing this
+   record.
 
-The following issues appear stale or closeable based on current evidence, but
-were not closed automatically:
+## Release Hold
 
-| Issue | Proposed disposition |
-|-------|----------------------|
-| #167 | Keep open until default-branch rescan and no-patch/transitive dispositions are recorded. Branch remediation is pushed at `3e6e791e`; GraphQL remains the reliable export path. |
-| #108 | Close after maintainer approval; the original peer-configuration issue is stale after current code and lab verification. |
-| #168 | Keep open until public release approval is recorded, even though post-merge CI and RC artifact/lab gates now passed. |
-| #166 | Keep open until the final decision record is accepted; current branch protection is materially hardened for solo development. |
+Do not publish a final tagged GitHub Release in the same step as the visibility
+flip. The binary release should be promoted separately after choosing:
+
+1. public version/tag name,
+2. release notes,
+3. whether to publish a prerelease first,
+4. whether to reuse the validated Actions snapshot artifacts or generate a
+   tag-triggered release run.
+
+Until then, the final validated launch artifact is the private Actions snapshot
+from run `25047595583` at commit `600de6963790e12bf3bea15f78f01714e054663b`.
+
+## Issue Disposition
+
+| Issue | State |
+|-------|-------|
+| #167 | Closed completed after dependency remediation and alert disposition. |
+| #170 | Closeable after posting PR #186, branch-protection, CodeQL baseline, and final main CI evidence. |
+| #168 | Closeable after posting final `600de696` CI, artifact checksum/SBOM, lab smoke, and stale-release-draft evidence. |
+| #149 | Closeable after #168/#170 are closed; the v0.69.0 sync is complete on `main`. |
 
 ## Final Position
 
-The project is **GO for continued private preparation**.
+The project is **GO for public repository visibility** after this decision
+record merges through the protected branch and final maintainer approval is
+recorded.
 
-The project is **NO-GO for public visibility or public release** until the hard
-blockers above are resolved or explicitly accepted in a final maintainer
-approval record.
+The project is **HOLD for a public tagged binary release** until the explicit
+release-promotion decision above is made.


### PR DESCRIPTION
## Summary

Updates `docs/PUBLIC-RELEASE-READINESS.md` from the stale 2026-04-27 NO-GO record to the current 2026-04-28 public visibility decision.

The record now separates public repository visibility from a later tagged binary release promotion, and captures the final evidence from:

- `main` commit `600de6963790e12bf3bea15f78f01714e054663b`
- final green `main` CI and release workflow run `25047595583`
- branch protection with 48 strict required contexts, including CodeQL PR contexts
- CodeQL and Dependabot closeout state
- final downloaded-artifact checksum/SBOM validation
- final VM102 lab smoke with the downloaded `netbird-machine.exe`
- stale `v0.1.0` release moved to Draft so no old public release is exposed

## Validation

- `git diff --check -- docs/PUBLIC-RELEASE-READINESS.md`
- live GitHub checks before authoring: repo still private, required contexts count 48, Dependabot open alerts 0, CodeQL open baseline 142 medium / 2 warning / 0 critical / 0 high, no non-draft releases via `gh release list --exclude-drafts`
