### PR TITLE
[management] stabilize experimental network map test

### DIFF
--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -235,16 +235,13 @@ func testGetNetworkMapGeneral(t *testing.T) {
 		return
 	}
 
-	networkMap, err := manager.GetNetworkMap(context.Background(), peer1.ID)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	if len(networkMap.Peers) != 1 {
-		t.Errorf("expecting Account NetworkMap to have 1 peers, got %v", len(networkMap.Peers))
-		return
-	}
+	var networkMap *types.NetworkMap
+	var networkMapErr error
+	require.Eventually(t, func() bool {
+		networkMap, networkMapErr = manager.GetNetworkMap(context.Background(), peer1.ID)
+		return networkMapErr == nil && networkMap != nil && len(networkMap.Peers) == 1
+	}, 3*time.Second, 25*time.Millisecond, "expecting Account NetworkMap to have 1 peer")
+	require.NoError(t, networkMapErr)
 
 	if networkMap.Peers[0].Key != peerKey2.PublicKey().String() {
 		t.Errorf(

--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -40,8 +40,9 @@ import (
 
 func runTestForAllEngines(t *testing.T, testDataFile string, f func(t *testing.T, store Store)) {
 	t.Helper()
+	engineFilter := os.Getenv("NETBIRD_STORE_ENGINE")
 	for _, engine := range supportedEngines {
-		if os.Getenv("NETBIRD_STORE_ENGINE") != "" && os.Getenv("NETBIRD_STORE_ENGINE") != string(engine) {
+		if engineFilter != "" && engineFilter != string(engine) {
 			continue
 		}
 		t.Setenv("NETBIRD_STORE_ENGINE", string(engine))
@@ -51,7 +52,9 @@ func runTestForAllEngines(t *testing.T, testDataFile string, f func(t *testing.T
 		t.Run(string(engine), func(t *testing.T) {
 			f(t, store)
 		})
-		os.Unsetenv("NETBIRD_STORE_ENGINE")
+		if engineFilter == "" {
+			os.Unsetenv("NETBIRD_STORE_ENGINE")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stabilize `TestAccountManager_GetNetworkMap_Experimental` by waiting briefly for the expected peer view.
- Preserve the original `NETBIRD_STORE_ENGINE` matrix filter inside `runTestForAllEngines` so a filtered sqlite job cannot become unfiltered mid-test.
- Test-only changes; no runtime behavior changes.

## Root cause
Two independent test-harness issues surfaced while closing the public-readiness gates:

1. The experimental `NetworkMapBuilder` updates peer views asynchronously after `AddPeer`. The test immediately read `GetNetworkMap`, which can observe `0` peers before the async cache update lands.
2. `runTestForAllEngines` re-read `NETBIRD_STORE_ENGINE` each loop iteration but called `os.Unsetenv("NETBIRD_STORE_ENGINE")` after the first subtest. In a matrix job named `Management / Unit (amd64, sqlite)`, that let later PostgreSQL/MySQL subtests run inside the sqlite job. This is why PR #188 initially failed in `Test_SaveAccount_Large/postgres` under a sqlite context.

## Evidence
- PR #187 head `c5266bf` and merge commit `bd5a7fba` have the same tree.
- The PR Linux sqlite job passed on `c5266bf`, while the `main` push Linux sqlite job failed twice in `TestAccountManager_GetNetworkMap_Experimental`.
- PR #188 first run showed a different failure: `Management / Unit (amd64, sqlite)` failed in `Test_SaveAccount_Large/postgres`, proving the matrix filter was not held stable.

## Validation
- `NETBIRD_STORE_ENGINE=sqlite CI=true go test -tags=devcert -run '^TestAccountManager_GetNetworkMap_Experimental$' -count=30 ./management/server`
- `NETBIRD_STORE_ENGINE=sqlite CI=true go test -tags=devcert -timeout 20m -count=1 ./management/server`
- `NETBIRD_STORE_ENGINE=sqlite CI=true go test -tags=devcert -run '^Test_SaveAccount_Large$' -count=1 -v ./management/server/store`
- `CI=true go test -tags=devcert -run '^Test_SaveAccount_Large$' -count=1 -v ./management/server/store`
- `git diff --check -- management/server/peer_test.go management/server/store/sql_store_test.go`

## Notes
A broader local management-suite command was attempted earlier, but the local host hit `/tmp` quota during linking (`disk quota exceeded` / `No space left on device`), so it is not counted as functional evidence.
