### PR TITLE
[doc] batch final public readiness corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project is a fork of [NetBird](https://github.com/netbirdio/netbird). The f
 ### Notes
 
 - CrowdSec code is included from upstream but is not enabled in the Machine Tunnel lab profile.
-- Machine Tunnel public release validation has passed local, CI, and lab gates on the upgrade branch; post-merge main smoke, release-candidate artifact validation, and final go-live approval remain required before publishing a public tag.
+- Machine Tunnel public visibility validation has passed PR CI, post-merge `main` CI, security, release-artifact, and VM102 downloaded-artifact lab gates. A public tagged binary release remains a separate HOLD decision until the tag, version, release notes, and final artifact promotion path are approved.
 
 ## [1.0.0-machine-tunnel] - 2026-02-05
 

--- a/FORK_DIFF.md
+++ b/FORK_DIFF.md
@@ -8,16 +8,16 @@ Baseline used for review: upstream NetBird `v0.70.0`.
 
 ## Generated Review Metrics
 
-The following values are generated from the current sprint branch against
+The following values are generated from the current protected `main` branch against
 upstream `v0.70.0`; they are review aids, not hand-maintained estimates:
 
 - `git diff --name-only v0.70.0...HEAD | wc -l`
-  - `263` changed files.
+  - `264` changed files.
 - `git diff --name-status v0.70.0...HEAD`
-  - `145` added files, `110` modified files, `8` deleted files.
+  - `145` added files, `111` modified files, `8` deleted files.
 - Top-level distribution:
   - `client`: `93`
-  - `management`: `57`
+  - `management`: `58`
   - `.github`: `35`
   - `scripts`: `20`
   - `docs`: `9`

--- a/docs/PUBLIC-RELEASE-READINESS.md
+++ b/docs/PUBLIC-RELEASE-READINESS.md
@@ -14,14 +14,14 @@ hold and must be promoted separately.
 | Area | State | Evidence |
 |------|-------|----------|
 | Repository visibility | PASS / still private | `gh repo view silentspike/netbird-machine-tunnel` reports `visibility=PRIVATE`, `isPrivate=true`. |
-| Current launch candidate | PASS | Protected `main` is at `0acb92e1ac82bd65194a0b03f9864bda5b657011`, the merge commit for PR #191. |
+| Current launch candidate | PASS | The validated feature launch commit is `0acb92e1ac82bd65194a0b03f9864bda5b657011`, the merge commit for PR #191. Protected `main` may include later documentation-only readiness commits; the current protected `main` commit must have green post-merge CI immediately before the visibility flip. |
 | Upstream baseline | PASS | Fork is synced through upstream NetBird `v0.70.0`; `upstream/main` commits after the tag remain intentionally out of scope. |
 | PR #191 | PASS | PR #191 merged at `2026-04-29T06:44:54Z` with merge commit `0acb92e1ac82bd65194a0b03f9864bda5b657011`. |
 | PR #191 required checks | PASS | Final PR head `b7775adb` completed 48/48 required checks successfully. |
-| Post-merge main CI | PASS | Main push CI for `0acb92e1` completed 12/12 push workflows successfully. The Linux workflow was recovered by rerunning only the cancelled failed jobs after two unit jobs hung. |
+| Post-merge main CI | PASS | Main push CI for the feature launch commit `0acb92e1` completed 12/12 push workflows successfully. The Linux workflow was recovered by rerunning only the cancelled failed jobs after two unit jobs hung. The readiness-record update merge commit `0f9abc98a33a935770ce9cdc44d96d61e24fc0c9` also completed 12/12 post-merge `main` push workflows successfully. |
 | Branch protection | PASS | `main` uses strict required checks with 48 contexts, including `CodeQL (go)` and `CodeQL (javascript-typescript)`, with admin enforcement enabled. |
 | PR conversations | PASS | PR #191 has 0 unresolved review conversations after the CodeQL log-injection threads were fixed and resolved. |
-| CodeQL / code scanning | PASS | Open main code-scanning alerts by `rule.security_severity_level`: `99 medium`, `1 null`, `0 critical`, `0 high`. The PR-blocking `go/log-injection` alert for `management/server/policy.go` is not open on `main`. |
+| CodeQL / code scanning | PASS | Open main code-scanning alerts by `rule.security_severity_level`: `142 medium`, `2 null`, `0 critical`, `0 high`. The PR-blocking `go/log-injection` alert for `management/server/policy.go` is not open on `main`. |
 | Dependabot alerts | PASS | Open Dependabot alerts are `0`. |
 | Issue board public hygiene | PASS | Open `priority:critical` issue count is `0`; open `priority:high` issue count is `0`. Issue #189 remains open as a medium upstream-sync tracking issue, but the v0.70.0 sync implementation has merged via PR #191. |
 | Published releases | PASS | `gh release list` shows only draft `v0.1.0`; there is no published non-draft release that would become public accidentally. |

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -158,6 +158,6 @@ Before public binary release:
 ```bash
 gh run list --repo silentspike/netbird-machine-tunnel --branch main --limit 20
 gh api repos/silentspike/netbird-machine-tunnel/dependabot/alerts --jq '[.[] | select(.state == "open")] | length'
-gh api 'repos/silentspike/netbird-machine-tunnel/code-scanning/alerts?state=open&per_page=100' --paginate --slurp \
+gh api 'repos/silentspike/netbird-machine-tunnel/code-scanning/alerts?state=open&ref=refs/heads/main&per_page=100' --paginate --slurp \
   | jq 'flatten | group_by(.rule.security_severity_level // "null") | map({level: (.[0].rule.security_severity_level // "null"), count: length})'
 ```


### PR DESCRIPTION
## Summary

- correct the public-readiness record after the docs merge commit made the previous `main` SHA wording stale
- update the live CodeQL security-severity aggregate to `142 medium`, `2 null`, `0 high`, `0 critical`
- refresh `FORK_DIFF.md` generated metrics against protected `main`
- clarify the changelog and maintenance CodeQL command for the public visibility gate

## Validation

- `git diff --check HEAD~1..HEAD`
- live final gate refresh before this PR: protected `main` post-merge push CI for `0f9abc98a33a935770ce9cdc44d96d61e24fc0c9` completed 12/12 successfully
- live code-scanning aggregation used `gh api ... --paginate --slurp` on `refs/heads/main`

## Scope

Docs-only final public-readiness correction. No code, workflow, artifact, release, or lab-state changes.