### PR TITLE
[misc] security: supply-chain / dev-environment hardening (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,6 +19,11 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (egress audit)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -14,7 +14,8 @@ All information in this guide has been verified against the actual codebase and 
 4. [Certificate Requirements](#certificate-requirements)
 5. [Multi-Tenant Isolation](#multi-tenant-isolation)
 6. [Signal and Relay Trust Model](#signal-and-relay-trust-model)
-7. [Security Checklist](#security-checklist)
+7. [Supply-Chain and Developer-Environment Security](#supply-chain-and-developer-environment-security)
+8. [Security Checklist](#security-checklist)
 
 ---
 
@@ -398,6 +399,61 @@ Successful authentication looks like:
 ```
 INFO grpc/machine_tunnel.go: Machine peer registration: hostname=DESKTOP-ABC domain=corp.local account=abc123...
 ```
+
+---
+
+## Supply-Chain and Developer-Environment Security
+
+Recent self-replicating worms in the JavaScript and Go ecosystems (the
+Shai-Hulud / "Miasma mini" family) have moved their target from application
+**dependencies** to the **developer environment itself**. Instead of malicious
+code in `node_modules`, the payload is hidden inside repository configuration
+that runs automatically when a project is opened or a coding session starts:
+
+- `.vscode/tasks.json` folder-open tasks
+- editor/agent hooks (for example an AI coding-tool `settings.json` session hook)
+- CI/CD workflow files
+
+Because the code runs from project config rather than from an install step,
+`--ignore-scripts` does **not** stop it. The worm scans for credentials
+(SCM tokens, cloud keys, SSH keys), exfiltrates them, and republishes poisoned
+artifacts using the stolen tokens.
+
+This repository is a Go project that ships editor/agent configuration and
+GitHub Actions workflows, so it is in scope for this class of attack. The
+following controls apply.
+
+### For Contributors and Maintainers
+
+| Control | Why |
+|---------|-----|
+| **Treat cloned repo config as executable code.** Review `.vscode/`, editor/agent config, and `.github/workflows/` **before** opening a freshly cloned repo or a pulled dependency's source in your editor. | The payload fires on folder-open / session-start, before you run anything. |
+| **Disable automatic tasks in VS Code** (`"task.allowAutomaticTasks": "off"`). | A folder-open task cannot run without explicit confirmation. |
+| **Use short-lived, least-privilege tokens; prefer OIDC over long-lived PATs.** | A token that cannot be stolen and reused breaks the worm's replication path. |
+| **Never store long-lived secrets in the developer or CI environment.** Use a password manager / secret store; rotate on any suspicion. | Limits blast radius if a session is compromised. |
+| **Pin third-party GitHub Actions to a full commit SHA**, not a moving tag. | A hijacked action tag cannot silently push new code into CI. |
+
+### CI/CD Controls
+
+- **Egress filtering on runners.** Workflows use `step-security/harden-runner`
+  (SHA-pinned) so that, even if malicious code executes, it cannot send stolen
+  credentials to an attacker-controlled host. The policy starts in `audit` mode
+  to establish a baseline of legitimate egress, then moves to `block` with an
+  explicit allowlist.
+- **Fork-safe secret guards.** Release/signing jobs are gated so that pull
+  requests and forks never require or expose Docker/registry/signing secrets.
+- **Least-privilege `GITHUB_TOKEN`.** Workflows declare minimal `permissions`.
+- **Untrusted PR code stays on GitHub-hosted runners.** PRs are not executed on
+  self-hosted runners that have internal network reachability.
+
+### Upstream-Sync IoC Scan
+
+On every upstream sync, maintainers run a supply-chain indicator-of-compromise
+scan over the incoming diff before merging. It flags newly added JavaScript,
+injected editor/agent config, known-malicious module names, and credential-
+exfiltration patterns (`atob(`, base64-decoded buffers, `child_process`,
+`trufflehog`, webhook exfil endpoints, `bun` staging). A merge does not proceed
+until the scan is clean and the result is recorded in the sync evidence log.
 
 ---
 


### PR DESCRIPTION
Closes #222

## Summary

Defends against the Shai-Hulud / "Miasma mini" worm class that now crosses into the
Go ecosystem and targets the **developer environment** (editor/agent config, VS Code
tasks, CI workflows) rather than dependencies. `--ignore-scripts` does not stop it.

A full IoC scan of the working tree and the `v0.66.4..v0.69.0` upstream diff found
**no infection** in this repo. This PR adds documentation + one concrete CI control.

## Changes

- **docs/SECURITY-HARDENING.md**: new "Supply-Chain and Developer-Environment Security"
  section (threat model, contributor/maintainer controls, CI/CD controls, upstream-sync
  IoC scan policy). Public-safe; no internal topology.
- **.github/workflows/secret-scan.yml**: SHA-pinned `step-security/harden-runner`
  (`v2.20.0` = `bf7454d06d71f1098171f2acdf0cd4708d7b5920`) in `egress-policy: audit`.
  Establishes a runner egress baseline before moving to `block`.

## Deliberately NOT done

- npm `minimum-release-age`: native npm 11.x does not support this key (pnpm/bun only)
  → would be a silent no-op / false security. Documented instead.
- `harden-runner` on `release.yml` / `golang-test-*` / `codeql`: folded into the v0.69.0
  upstream sync to avoid guaranteed merge conflicts with the upstream workflow rewrites.

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [x] harden-runner SHA verified against `v2.20.0` (ref + tags API agree)
- [x] IoC scan of working tree + upstream diff: clean
- [ ] GitHub Actions green on this PR
- [ ] Confirm harden-runner audit step runs without breaking gitleaks job

## Follow-ups

- After a baseline run, flip `egress-policy: audit` → `block` with an allowlist.
- Fold `harden-runner` into upstream workflows during the v0.69.0 sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)